### PR TITLE
feat(button): add filled tonal button and fix ripple/nav-tab states

### DIFF
--- a/src/components/button/MdButtonBase.vue
+++ b/src/components/button/MdButtonBase.vue
@@ -50,8 +50,19 @@ defineProps({
     z-index: 0;
   }
 
-  > * {
+  > .md-ripple {
     z-index: 1;
+  }
+
+  > :not(.md-button__background):not(.md-ripple) {
+    z-index: 2;
+  }
+
+  .md-ripple-surface {
+    &::before,
+    &::after {
+      z-index: 0;
+    }
   }
 
   &:disabled {

--- a/src/components/button/MdFilledTonalButton.vue
+++ b/src/components/button/MdFilledTonalButton.vue
@@ -1,0 +1,71 @@
+<template>
+  <MdButtonBase class="md-filled-tonal-button" :disabled="disabled">
+    <MdRipple />
+    <span v-if="label" class="md-button__label">
+      {{ label }}
+    </span>
+    <span v-else class="md-button__label">
+      <slot />
+    </span>
+  </MdButtonBase>
+</template>
+
+<script setup>
+import MdButtonBase from './MdButtonBase.vue';
+import MdRipple from '../ripple/MdRipple.vue';
+
+defineProps({
+  label: {
+    type: String,
+  },
+  disabled: {
+    type: Boolean,
+  },
+});
+</script>
+
+<style lang="scss">
+@use 'sass:map';
+@use '../../styles/tokens';
+@use '../ripple/ripple';
+@use '../elevation/elevation';
+
+$theme: tokens.md-comp-filled-tonal-button-values();
+
+.md-filled-tonal-button {
+  height: map.get($theme, container-height);
+  border-radius: map.get($theme, container-shape);
+  box-shadow: elevation.resolve-box-shadow(map.get($theme, container-elevation), map.get($theme, container-shadow-color));
+  @include ripple.ripple($theme, null, 100px);
+
+  &:hover:not(:focus):not(:active):not(:disabled) {
+    box-shadow: elevation.resolve-box-shadow(map.get($theme, hover-container-elevation), map.get($theme, container-shadow-color));
+  }
+
+  .md-button__label {
+    color: map.get($theme, label-text-color);
+    font-family: map.get($theme, label-text-font);
+    font-size: map.get($theme, label-text-size);
+    font-weight: map.get($theme, label-text-weight);
+    letter-spacing: map.get($theme, label-text-tracking);
+    line-height: map.get($theme, label-text-line-height);
+  }
+
+  .md-button__background {
+    background-color: map.get($theme, container-color);
+  }
+
+  &:disabled {
+    box-shadow: elevation.resolve-box-shadow(map.get($theme, disabled-container-elevation), map.get($theme, container-shadow-color));
+
+    .md-button__background {
+      background-color: map.get($theme, disabled-container-color);
+      opacity: map.get($theme, disabled-container-opacity);
+    }
+    .md-button__label {
+      color: map.get($theme, disabled-label-text-color);
+      opacity: map.get($theme, disabled-label-text-opacity);
+    }
+  }
+}
+</style>

--- a/src/components/navigation-tab/MdNavigationTab.vue
+++ b/src/components/navigation-tab/MdNavigationTab.vue
@@ -24,7 +24,7 @@ defineProps({
 @use 'sass:map';
 @use '../../styles/tokens';
 
-$theme: tokens.md-comp-primary-navigation-tab-values();
+$theme: tokens.md-comp-navigation-bar-values();
 
 .md-navigation-tab {
   align-items: center;
@@ -47,42 +47,56 @@ $theme: tokens.md-comp-primary-navigation-tab-values();
   font: inherit;
 
   &__content {
-    display: grid;
-    grid-auto-columns: 1fr;
-    grid-auto-flow: column;
-    grid-auto-rows: auto;
+    position: relative;
+    display: flex;
+    width: map.get($theme, active-indicator-width);
+    height: map.get($theme, active-indicator-height);
+    justify-content: center;
     align-items: center;
+    margin-bottom: 4px;
+
     .md-navigation-tab__active-indicator {
-      grid-column: 1 / 2;
-      grid-row: 1 / 2;
-      display: flex;
-      width: 100%;
+      position: absolute;
+      inset: 0;
+      width: 32px;
       height: map.get($theme, active-indicator-height);
       border-radius: map.get($theme, active-indicator-shape);
+      opacity: 0;
+      transition: width 100ms cubic-bezier(0.2, 0, 0, 1), opacity 100ms cubic-bezier(0.2, 0, 0, 1);
     }
+
     .md-navigation-tab__icon {
-      grid-column: 1 / 2;
-      grid-row: 1 / 2;
+      position: relative;
+      z-index: 1;
+      color: map.get($theme, inactive-icon-color);
+      font-size: map.get($theme, icon-size);
+      --mdc-icon-size: #{map.get($theme, icon-size)};
     }
   }
 
   &__label {
-    margin-top: 4px;
-    font-family: map.get($theme, with-label-text-label-text-font);
-    font-size: map.get($theme, with-label-text-label-text-size);
-    line-height: map.get($theme, with-label-text-label-text-line-height);
-    letter-spacing: map.get($theme, with-label-text-label-text-tracking);
-    font-weight: map.get($theme, with-label-text-label-text-weight);
-    color: map.get($theme, with-label-text-inactive-label-text-color);
+    font-family: map.get($theme, label-text-font);
+    font-size: map.get($theme, label-text-size);
+    line-height: map.get($theme, label-text-line-height);
+    letter-spacing: map.get($theme, label-text-tracking);
+    font-weight: map.get($theme, label-text-weight);
+    color: map.get($theme, inactive-label-text-color);
   }
 
   &--selected {
     .md-navigation-tab__label {
-      color: map.get($theme, with-label-text-active-label-text-color);
+      color: map.get($theme, active-label-text-color);
+      font-weight: map.get($theme, active-label-text-weight);
+    }
+
+    .md-navigation-tab__icon {
+      color: map.get($theme, active-icon-color);
     }
 
     .md-navigation-tab__active-indicator {
       background-color: map.get($theme, active-indicator-color);
+      width: map.get($theme, active-indicator-width);
+      opacity: 1;
     }
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 export { default as MdElevatedButton } from './components/button/MdElevatedButton.vue';
 export { default as MdFilledButton } from './components/button/MdFilledButton.vue';
+export { default as MdFilledTonalButton } from './components/button/MdFilledTonalButton.vue';
 export { default as MdSearch } from './components/search/MdSearch.vue';
 export { default as MdTextButton } from './components/button/MdTextButton.vue';
 export { default as MdOutlinedButton } from './components/button/MdOutlinedButton.vue';

--- a/stories/components/button/MdFilledTonalButton.stories.js
+++ b/stories/components/button/MdFilledTonalButton.stories.js
@@ -1,0 +1,20 @@
+import MdFilledTonalButton from '../../../src/components/button/MdFilledTonalButton.vue';
+
+export default {
+  title: 'Components/Buttons',
+  component: MdFilledTonalButton,
+  argTypes: {},
+};
+
+const Template = (args) => ({
+  components: { MdFilledTonalButton },
+  setup() {
+    return { args };
+  },
+  template: '<md-filled-tonal-button v-bind="args" />',
+});
+
+export const FilledTonalButton = Template.bind({});
+FilledTonalButton.args = {
+  label: 'Button',
+};


### PR DESCRIPTION
## Summary
This PR delivers **W1-01 (MdFilledTonalButton)** and includes the required UI stability fixes discovered during manual QA.

## Scope
- Add new `MdFilledTonalButton` component
- Export it from package entry
- Add Storybook coverage
- Fix ripple layering for filled/elevated/tonal buttons
- Fix NavigationTab active indicator rendering to match navigation bar behavior (pill background, not bottom line)

## Changes
### 1) New component: `MdFilledTonalButton`
- Added: `src/components/button/MdFilledTonalButton.vue`
- Uses `tokens.md-comp-filled-tonal-button-values()`
- Supports `label` and slot content
- Disabled state and elevations wired from tokens

### 2) Public export update
- Updated: `src/main.js`
- Added export: `MdFilledTonalButton`

### 3) Storybook
- Added: `stories/components/button/MdFilledTonalButton.stories.js`
- Scenario: basic filled tonal button

### 4) Ripple layering fix (regression fix)
- Updated: `src/components/button/MdButtonBase.vue`
- Fixed layer ordering so state-layer ripple is visible on filled/elevated/tonal buttons:
  - background layer
  - ripple layer
  - foreground content layer

### 5) Navigation tab active indicator fix
- Updated: `src/components/navigation-tab/MdNavigationTab.vue`
- Active indicator rendered as icon-background pill in selected state (no bottom line behavior)
- Indicator width behavior aligned with navigation bar style (compact -> expanded in active state)

## Validation
- ESLint passed for modified files used in this workstream.
- Storybook build passed locally (`NODE_OPTIONS=--openssl-legacy-provider`).
- Boilerplate app build passed after integration checks.
- Manual QA confirmed:
  - Filled/Elevated/FilledTonal buttons show ripple again
  - Navigation tab indicator no longer renders as an unwanted bottom line

## Notes
- Boilerplate-only demo/test edits were intentionally not included in this library PR.

Closes #34
