### PR TITLE
feat(button): W1-02 button API parity

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore",
-    "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
+    "storybook": "NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6006",
+    "build-storybook": "NODE_OPTIONS=--openssl-legacy-provider build-storybook",
     "deploy-storybook": "gh-pages -d storybook-static",
     "semantic-release": "semantic-release"
   },

--- a/src/components/button/MdButtonBase.vue
+++ b/src/components/button/MdButtonBase.vue
@@ -1,19 +1,56 @@
 <template>
-  <button class="md-button" :disabled="disabled">
+  <component
+    :is="href ? 'a' : 'button'"
+    class="md-button"
+    :class="{ 'md-button--soft-disabled': softDisabled }"
+    :disabled="href ? undefined : disabled"
+    :type="href ? undefined : type"
+    :href="href || undefined"
+    :target="href ? target || undefined : undefined"
+    :download="href ? download || undefined : undefined"
+    :aria-disabled="disabled || softDisabled || undefined"
+    :tabindex="href && disabled && !softDisabled ? -1 : undefined"
+    @click="handleClick"
+  >
     <div class="md-button__background"></div>
     <slot />
-  </button>
+  </component>
 </template>
 
 <script setup>
-defineProps({
-  label: {
-    type: String,
-  },
+const props = defineProps({
   disabled: {
     type: Boolean,
+    default: false,
+  },
+  softDisabled: {
+    type: Boolean,
+    default: false,
+  },
+  href: {
+    type: String,
+    default: '',
+  },
+  download: {
+    type: String,
+    default: '',
+  },
+  target: {
+    type: String,
+    default: '',
+  },
+  type: {
+    type: String,
+    default: 'button',
   },
 });
+
+const handleClick = (event) => {
+  if (props.softDisabled || (props.disabled && props.href)) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  }
+};
 </script>
 
 <style lang="scss">
@@ -38,7 +75,7 @@ defineProps({
   padding: 0 20px;
   -webkit-font-smoothing: antialiased;
 
-  &:not(:disabled):hover {
+  &:not(:disabled):not(.md-button--soft-disabled):hover {
     box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.3), 0px 1px 3px 1px rgba(0, 0, 0, 0.15);
     cursor: pointer;
   }
@@ -48,6 +85,12 @@ defineProps({
     inset: 0;
     border-radius: inherit;
     z-index: 0;
+  }
+
+  &__trailing-icon {
+    display: inline-flex;
+    align-items: center;
+    margin-inline-start: 8px;
   }
 
   > .md-ripple {
@@ -65,7 +108,8 @@ defineProps({
     }
   }
 
-  &:disabled {
+  &:disabled,
+  &.md-button--soft-disabled {
     .md-ripple {
       opacity: 0;
     }

--- a/src/components/button/MdElevatedButton.vue
+++ b/src/components/button/MdElevatedButton.vue
@@ -1,5 +1,13 @@
 <template>
-  <MdButtonBase class="md-elevated-button" :disabled="disabled">
+  <MdButtonBase
+    class="md-elevated-button"
+    :disabled="disabled"
+    :soft-disabled="softDisabled"
+    :href="href"
+    :target="target"
+    :download="download"
+    :type="type"
+  >
     <MdRipple />
     <span v-if="label" class="md-button__label">
       {{ label }}
@@ -7,19 +15,27 @@
     <span v-else class="md-button__label">
       <slot />
     </span>
+    <span v-if="trailingIcon || $slots['trailing-icon']" class="md-button__trailing-icon">
+      <slot name="trailing-icon">
+        <MdIcon>{{ trailingIcon }}</MdIcon>
+      </slot>
+    </span>
   </MdButtonBase>
 </template>
 
 <script setup>
 import MdButtonBase from './MdButtonBase.vue';
+import { buttonSharedProps } from './buttonSharedProps';
 import MdRipple from '../ripple/MdRipple.vue';
+import MdIcon from '../icon/MdIcon.vue';
 
 defineProps({
+  ...buttonSharedProps,
   label: {
     type: String,
   },
-  disabled: {
-    type: Boolean,
+  trailingIcon: {
+    type: String,
   },
 });
 </script>
@@ -40,7 +56,7 @@ $theme: tokens.md-comp-elevated-button-values();
   box-shadow: elevation.resolve-box-shadow(map.get($theme, container-elevation), map.get($theme, container-shadow-color));
   @include ripple.ripple($theme, null, 100px);
 
-  &:hover:not(:focus):not(:active):not(:disabled) {
+  &:hover:not(:focus):not(:active):not(:disabled):not(.md-button--soft-disabled) {
     box-shadow: elevation.resolve-box-shadow(map.get($theme, hover-container-elevation), map.get($theme, container-shadow-color));
   }
 
@@ -52,18 +68,21 @@ $theme: tokens.md-comp-elevated-button-values();
     letter-spacing: map.get($theme, label-text-tracking);
     line-height: map.get($theme, label-text-line-height);
   }
+
   .md-button__background {
     background-color: map.get($theme, container-color);
   }
 
-  &:disabled {
+  &:disabled,
+  &.md-button--soft-disabled {
     box-shadow: none;
 
     .md-button__background {
       background-color: map.get($theme, disabled-container-color);
       opacity: map.get($theme, disabled-container-opacity);
     }
-    .md-button__label {
+    .md-button__label,
+    .md-button__trailing-icon {
       color: map.get($theme, disabled-label-text-color);
       opacity: map.get($theme, disabled-label-text-opacity);
     }

--- a/src/components/button/MdFilledButton.vue
+++ b/src/components/button/MdFilledButton.vue
@@ -1,5 +1,13 @@
 <template>
-  <MdButtonBase class="md-filled-button" :disabled="disabled">
+  <MdButtonBase
+    class="md-filled-button"
+    :disabled="disabled"
+    :soft-disabled="softDisabled"
+    :href="href"
+    :target="target"
+    :download="download"
+    :type="type"
+  >
     <MdRipple />
     <span v-if="label" class="md-button__label">
       {{ label }}
@@ -7,19 +15,27 @@
     <span v-else class="md-button__label">
       <slot />
     </span>
+    <span v-if="trailingIcon || $slots['trailing-icon']" class="md-button__trailing-icon">
+      <slot name="trailing-icon">
+        <MdIcon>{{ trailingIcon }}</MdIcon>
+      </slot>
+    </span>
   </MdButtonBase>
 </template>
 
 <script setup>
 import MdButtonBase from './MdButtonBase.vue';
+import { buttonSharedProps } from './buttonSharedProps';
 import MdRipple from '../ripple/MdRipple.vue';
+import MdIcon from '../icon/MdIcon.vue';
 
 defineProps({
+  ...buttonSharedProps,
   label: {
     type: String,
   },
-  disabled: {
-    type: Boolean,
+  trailingIcon: {
+    type: String,
   },
 });
 </script>
@@ -37,7 +53,7 @@ $theme: tokens.md-comp-filled-button-values();
   box-shadow: none;
   @include ripple.ripple($theme, null, 100px);
 
-  &:not(:disabled):hover {
+  &:not(:disabled):not(.md-button--soft-disabled):hover {
     box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.3), 0px 1px 3px 1px rgba(0, 0, 0, 0.15);
   }
 
@@ -54,12 +70,14 @@ $theme: tokens.md-comp-filled-button-values();
     background-color: map.get($theme, container-color);
   }
 
-  &:disabled {
+  &:disabled,
+  &.md-button--soft-disabled {
     .md-button__background {
       background-color: map.get($theme, disabled-container-color);
       opacity: map.get($theme, disabled-container-opacity);
     }
-    .md-button__label {
+    .md-button__label,
+    .md-button__trailing-icon {
       color: map.get($theme, disabled-label-text-color);
       opacity: map.get($theme, disabled-label-text-opacity);
     }

--- a/src/components/button/MdFilledTonalButton.vue
+++ b/src/components/button/MdFilledTonalButton.vue
@@ -1,5 +1,13 @@
 <template>
-  <MdButtonBase class="md-filled-tonal-button" :disabled="disabled">
+  <MdButtonBase
+    class="md-filled-tonal-button"
+    :disabled="disabled"
+    :soft-disabled="softDisabled"
+    :href="href"
+    :target="target"
+    :download="download"
+    :type="type"
+  >
     <MdRipple />
     <span v-if="label" class="md-button__label">
       {{ label }}
@@ -7,19 +15,27 @@
     <span v-else class="md-button__label">
       <slot />
     </span>
+    <span v-if="trailingIcon || $slots['trailing-icon']" class="md-button__trailing-icon">
+      <slot name="trailing-icon">
+        <MdIcon>{{ trailingIcon }}</MdIcon>
+      </slot>
+    </span>
   </MdButtonBase>
 </template>
 
 <script setup>
 import MdButtonBase from './MdButtonBase.vue';
+import { buttonSharedProps } from './buttonSharedProps';
 import MdRipple from '../ripple/MdRipple.vue';
+import MdIcon from '../icon/MdIcon.vue';
 
 defineProps({
+  ...buttonSharedProps,
   label: {
     type: String,
   },
-  disabled: {
-    type: Boolean,
+  trailingIcon: {
+    type: String,
   },
 });
 </script>
@@ -38,7 +54,7 @@ $theme: tokens.md-comp-filled-tonal-button-values();
   box-shadow: elevation.resolve-box-shadow(map.get($theme, container-elevation), map.get($theme, container-shadow-color));
   @include ripple.ripple($theme, null, 100px);
 
-  &:hover:not(:focus):not(:active):not(:disabled) {
+  &:hover:not(:focus):not(:active):not(:disabled):not(.md-button--soft-disabled) {
     box-shadow: elevation.resolve-box-shadow(map.get($theme, hover-container-elevation), map.get($theme, container-shadow-color));
   }
 
@@ -55,14 +71,16 @@ $theme: tokens.md-comp-filled-tonal-button-values();
     background-color: map.get($theme, container-color);
   }
 
-  &:disabled {
+  &:disabled,
+  &.md-button--soft-disabled {
     box-shadow: elevation.resolve-box-shadow(map.get($theme, disabled-container-elevation), map.get($theme, container-shadow-color));
 
     .md-button__background {
       background-color: map.get($theme, disabled-container-color);
       opacity: map.get($theme, disabled-container-opacity);
     }
-    .md-button__label {
+    .md-button__label,
+    .md-button__trailing-icon {
       color: map.get($theme, disabled-label-text-color);
       opacity: map.get($theme, disabled-label-text-opacity);
     }

--- a/src/components/button/MdOutlinedButton.vue
+++ b/src/components/button/MdOutlinedButton.vue
@@ -1,5 +1,13 @@
 <template>
-  <MdButtonBase class="md-outlined-button" :disabled="disabled">
+  <MdButtonBase
+    class="md-outlined-button"
+    :disabled="disabled"
+    :soft-disabled="softDisabled"
+    :href="href"
+    :target="target"
+    :download="download"
+    :type="type"
+  >
     <MdRipple />
     <div class="md-button__outline"></div>
     <span v-if="label" class="md-button__label">
@@ -8,19 +16,27 @@
     <span v-else class="md-button__label">
       <slot />
     </span>
+    <span v-if="trailingIcon || $slots['trailing-icon']" class="md-button__trailing-icon">
+      <slot name="trailing-icon">
+        <MdIcon>{{ trailingIcon }}</MdIcon>
+      </slot>
+    </span>
   </MdButtonBase>
 </template>
 
 <script setup>
 import MdButtonBase from './MdButtonBase.vue';
+import { buttonSharedProps } from './buttonSharedProps';
 import MdRipple from '../ripple/MdRipple.vue';
+import MdIcon from '../icon/MdIcon.vue';
 
 defineProps({
+  ...buttonSharedProps,
   label: {
     type: String,
   },
-  disabled: {
-    type: Boolean,
+  trailingIcon: {
+    type: String,
   },
 });
 </script>
@@ -57,11 +73,12 @@ $theme: tokens.md-comp-outlined-button-values();
     background-color: transparent;
   }
 
-  &:not(:disabled):hover {
+  &:not(:disabled):not(.md-button--soft-disabled):hover {
     box-shadow: none;
   }
 
-  &:disabled {
+  &:disabled,
+  &.md-button--soft-disabled {
     box-shadow: none;
 
     .md-button__outline {
@@ -71,7 +88,8 @@ $theme: tokens.md-comp-outlined-button-values();
       background-color: transparent;
       opacity: 1;
     }
-    .md-button__label {
+    .md-button__label,
+    .md-button__trailing-icon {
       color: map.get($theme, disabled-label-text-color);
       opacity: map.get($theme, disabled-label-text-opacity);
     }

--- a/src/components/button/MdTextButton.vue
+++ b/src/components/button/MdTextButton.vue
@@ -1,5 +1,13 @@
 <template>
-  <MdButtonBase class="md-text-button" :disabled="disabled">
+  <MdButtonBase
+    class="md-text-button"
+    :disabled="disabled"
+    :soft-disabled="softDisabled"
+    :href="href"
+    :target="target"
+    :download="download"
+    :type="type"
+  >
     <MdRipple />
     <span v-if="label" class="md-button__label">
       {{ label }}
@@ -7,19 +15,27 @@
     <span v-else class="md-button__label">
       <slot />
     </span>
+    <span v-if="trailingIcon || $slots['trailing-icon']" class="md-button__trailing-icon">
+      <slot name="trailing-icon">
+        <MdIcon>{{ trailingIcon }}</MdIcon>
+      </slot>
+    </span>
   </MdButtonBase>
 </template>
 
 <script setup>
 import MdButtonBase from './MdButtonBase.vue';
+import { buttonSharedProps } from './buttonSharedProps';
 import MdRipple from '../ripple/MdRipple.vue';
+import MdIcon from '../icon/MdIcon.vue';
 
 defineProps({
+  ...buttonSharedProps,
   label: {
     type: String,
   },
-  disabled: {
-    type: Boolean,
+  trailingIcon: {
+    type: String,
   },
 });
 </script>
@@ -44,12 +60,17 @@ $theme: tokens.md-comp-text-button-values();
   box-shadow: none;
   @include ripple.ripple($theme, null, 100px);
 
-  &:not(:disabled):hover {
+  &:not(:disabled):not(.md-button--soft-disabled):hover {
     box-shadow: none;
   }
 
-  &:disabled {
+  &:disabled,
+  &.md-button--soft-disabled {
     color: rgba(map.get($theme, disabled-label-text-color), map.get($theme, disabled-label-text-opacity));
+
+    .md-button__trailing-icon {
+      opacity: map.get($theme, disabled-label-text-opacity);
+    }
   }
 }
 </style>

--- a/src/components/button/buttonSharedProps.js
+++ b/src/components/button/buttonSharedProps.js
@@ -1,0 +1,26 @@
+export const buttonSharedProps = {
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  softDisabled: {
+    type: Boolean,
+    default: false,
+  },
+  href: {
+    type: String,
+    default: '',
+  },
+  download: {
+    type: String,
+    default: '',
+  },
+  target: {
+    type: String,
+    default: '',
+  },
+  type: {
+    type: String,
+    default: 'button',
+  },
+};


### PR DESCRIPTION
## Summary
Implements W1-02 button API parity for button variants with a Material Web-aligned base behavior.

## What changed
- Added shared button props contract via `buttonSharedProps` for consistent API surface across button variants.
- Updated `MdButtonBase` to support link mode (`href`, `target`, `download`) and `softDisabled` interaction blocking.
- Added trailing icon support across button variants (`trailingIcon` prop + `trailing-icon` slot).
- Updated Storybook scripts in `package.json` to include `NODE_OPTIONS=--openssl-legacy-provider` (Node 18 + Webpack4 compatibility).

## Files
- `src/components/button/MdButtonBase.vue`
- `src/components/button/MdFilledButton.vue`
- `src/components/button/MdElevatedButton.vue`
- `src/components/button/MdFilledTonalButton.vue`
- `src/components/button/MdOutlinedButton.vue`
- `src/components/button/MdTextButton.vue`
- `src/components/button/buttonSharedProps.js`
- `package.json`

## Validation
- `npm run storybook -- --smoke-test`
- `NODE_OPTIONS=--openssl-legacy-provider npm run build-storybook`

Closes #35
