### PR TITLE
ci: switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       #- name: install
       #  run: npm ci
       #- name: build
@@ -16,25 +16,27 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     steps:
       - id: release
-        uses: GoogleCloudPlatform/release-please-action@main
+        uses: GoogleCloudPlatform/release-please-action@v4
         with:
           release-type: node
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: ${{ steps.release.outputs.release_created }}
 
-      - name: Setupt Node.js 16.x
-        uses: actions/setup-node@v3
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
       - name: Publish package on NPM 📦
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Summary
- migrate npm publish in `release-please.yml` from token-based auth to GitHub OIDC trusted publishing
- grant `id-token: write` permission in release job
- update Actions versions (`actions/checkout`, `actions/setup-node`) and use release-please action `v4`
- publish with provenance (`npm publish --provenance`)

## Why
`NPM_TOKEN` rotation every 90 days is no longer practical. OIDC removes long-lived npm tokens and avoids recurring publish failures caused by expired/invalid secrets.

## Prerequisite
Trusted Publisher is configured on npm for:
- org/user: `mylmz10`
- repo: `vue-material-3`
- workflow: `release-please.yml`

## Changed file
- `.github/workflows/release-please.yml`