### PR TITLE
fix(select): add explicit zero gap on filled-select trigger

### DIFF
--- a/src/components/select/MdFilledSelect.vue
+++ b/src/components/select/MdFilledSelect.vue
@@ -524,6 +524,7 @@ $theme: tokens.md-comp-filled-select-values();
     border: none;
     cursor: pointer;
     display: inline-flex;
+    gap: 0;
     min-height: 56px;
     outline: none;
     padding: 0;


### PR DESCRIPTION
Test patch change to verify release automation can produce the next patch release from master. This is a minimal, no-op style normalization (gap: 0) in MdFilledSelect trigger styles.