### PR TITLE
fix(ci): force npm trusted publishing without auth token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,8 +35,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
       - name: Publish package on NPM 📦
-        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ''
+        run: npm publish --provenance --access public
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Release 0.8.1 run showed npm publish using NODE_AUTH_TOKEN and failing with 404. This patch removes setup-node registry auth wiring and explicitly clears NODE_AUTH_TOKEN so npm uses OIDC trusted publishing path only. Also adds --access public to publish command.