### PR TITLE
fix(ci): align npm trusted publishing prerequisites

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,13 +31,19 @@ jobs:
         uses: actions/checkout@v4
         if: ${{ steps.release.outputs.release_created }}
 
-      - name: Setup Node.js 20.x
+      - name: Setup Node.js 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
         if: ${{ steps.release.outputs.release_created }}
+
+      - name: Ensure npm 11.5.1+
+        run: |
+          npm install -g npm@^11.5.1
+          node --version
+          npm --version
+        if: ${{ steps.release.outputs.release_created }}
+
       - name: Publish package on NPM 📦
-        env:
-          NODE_AUTH_TOKEN: ''
-        run: npm publish --provenance --access public
+        run: npm publish --access public
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Updates release workflow to match npm trusted publishing requirements:
- Node.js 24
- npm 11.5.1+ enforced at runtime
- remove token-based env from publish step
- publish via OIDC path (`npm publish --access public`)