### PR TITLE
feat(text-field): complete W2-04 text field API/layout parity

### DIFF
--- a/src/components/field/MdField.vue
+++ b/src/components/field/MdField.vue
@@ -1,9 +1,20 @@
 <template>
-  <span class="md-field" :class="{ 'md-field--focused': focused, 'md-field--populated': populated, 'md-field--error': error }" @focusin="onFocusin" @focusout="onFocusout">
+  <span
+    class="md-field"
+    :class="{
+      'md-field--focused': focused,
+      'md-field--populated': populated,
+      'md-field--error': error,
+      'md-field--with-start': hasStartContent,
+      'md-field--with-end': hasEndContent,
+    }"
+    @focusin="onFocusin"
+    @focusout="onFocusout"
+  >
     <span class="md-field__container">
       <span class="md-field__outline"></span>
       <span class="md-field__state-layer"></span>
-      <span class="md-field__start">
+      <span class="md-field__start" :class="{ 'md-field__start--empty': !hasStartContent }">
         <slot name="start"></slot>
       </span>
       <span class="md-field__middle">
@@ -13,7 +24,7 @@
           <slot></slot>
         </span>
       </span>
-      <span class="md-field__end">
+      <span class="md-field__end" :class="{ 'md-field__end--empty': !hasEndContent }">
         <slot name="end"></slot>
       </span>
 
@@ -32,7 +43,7 @@
 </template>
 
 <script setup>
-import { ref } from 'vue';
+import { Comment, Text, computed, ref, useSlots } from 'vue';
 
 defineProps({
   disabled: { type: Boolean },
@@ -44,6 +55,28 @@ defineProps({
 });
 
 let focused = ref(false);
+const slots = useSlots();
+
+const hasRenderableVNode = (vnodes = []) => {
+  return vnodes.some((vnode) => {
+    if (vnode.type === Comment) {
+      return false;
+    }
+
+    if (vnode.type === Text) {
+      return typeof vnode.children === 'string' && vnode.children.trim().length > 0;
+    }
+
+    if (Array.isArray(vnode.children)) {
+      return hasRenderableVNode(vnode.children);
+    }
+
+    return true;
+  });
+};
+
+const hasStartContent = computed(() => hasRenderableVNode(slots.start?.() || []));
+const hasEndContent = computed(() => hasRenderableVNode(slots.end?.() || []));
 
 const onFocusin = () => {
   focused.value = true;
@@ -83,17 +116,24 @@ const onFocusout = () => {
   }
 
   &__start {
-    width: 16px;
+    width: auto;
+    min-width: 0;
     flex-shrink: 0;
+  }
+
+  &__start:not(.md-field__start--empty) {
+    min-width: 16px;
   }
 
   &__middle {
     position: relative;
-    width: 100%;
+    flex: 1 1 auto;
+    min-width: 0;
 
     #{$this}__label {
       position: absolute;
-      left: 0;
+      left: var(--md-field-label-offset, 0px);
+      padding: 0 16px;
       pointer-events: none;
       transition: 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
       transition-duration: 0.3s;
@@ -108,6 +148,20 @@ const onFocusout = () => {
     }
     #{$this}__content {
       width: 100%;
+      padding-inline-start: var(--md-field-leading-space, 16px);
+      padding-inline-end: var(--md-field-trailing-space, 16px);
+    }
+  }
+
+  &--with-start {
+    #{$this}__content {
+      padding-inline-start: 0;
+    }
+  }
+
+  &--with-end {
+    #{$this}__content {
+      padding-inline-end: 0;
     }
   }
 
@@ -115,7 +169,6 @@ const onFocusout = () => {
   &--populated {
     #{$this}__middle {
       #{$this}__label {
-        padding: 0 6px;
         transform: translateY(-27px) translateX(-15%) scale(0.75);
         background-color: #ffffff;
       }
@@ -129,7 +182,6 @@ const onFocusout = () => {
     &#{$this}--filled {
       #{$this}__middle {
         #{$this}__label {
-          padding: 0 6px;
           transform: translateY(-13px) translateX(-21%) scale(0.75);
           background: none;
         }
@@ -141,8 +193,14 @@ const onFocusout = () => {
   }
 
   &__end {
-    width: 24px;
+    width: auto;
+    min-width: 0;
+    justify-content: flex-end;
     flex-shrink: 0;
+  }
+
+  &__end:not(.md-field__end--empty) {
+    min-width: 16px;
   }
 
   &__state-layer {

--- a/src/components/text-field/MdFilledTextField.vue
+++ b/src/components/text-field/MdFilledTextField.vue
@@ -1,55 +1,202 @@
 <template>
   <span class="md-filled-text-field" @click="onClick">
-    <MdFilledField :error="error" :label="label" :populated="!!inputValue">
-      <MdTextFieldBase ref="textFieldEl" :value="inputValue" @input="onTextFieldInput" @focus="$emit('focus', $event)" @blur="$emit('blur', $event)" />
+    <MdFilledField :disabled="disabled" :error="error" :label="label" :populated="!!inputValue" :required="required" :style="{ '--md-field-label-offset': `${labelOffset}px` }">
+      <MdTextFieldBase
+        ref="textFieldEl"
+        :autocomplete="autocomplete"
+        :autofocus="autofocus"
+        :disabled="disabled"
+        :form="form"
+        :inputmode="inputmode"
+        :list="list"
+        :max="max"
+        :maxlength="maxlength"
+        :min="min"
+        :minlength="minlength"
+        :name="name"
+        :pattern="pattern"
+        :placeholder="placeholder"
+        :prefix="resolvedPrefix"
+        :readonly="readonly"
+        :required="required"
+        :step="step"
+        :suffix="suffix"
+        :type="type"
+        :value="inputValue"
+        :aria-invalid="ariaInvalid"
+        @input="onTextFieldInput"
+        @change="onTextFieldChange"
+        @focus="onTextFieldFocus"
+        @blur="onTextFieldBlur"
+        @select="$emit('select', $event)"
+        @keyup="$emit('keyup', $event)"
+        @keydown="$emit('keydown', $event)"
+        @invalid="$emit('invalid', $event)"
+      >
+        <template v-if="showPrefixSlot" #prefix>
+          <slot name="prefix" />
+        </template>
+        <template v-if="slots.suffix" #suffix>
+          <slot name="suffix" />
+        </template>
+      </MdTextFieldBase>
+
       <template #supporting-text>
-        <slot name="supporting-text" />
+        <slot name="supporting-text">{{ resolvedSupportingText }}</slot>
+      </template>
+      <template #supporting-text-end>
+        <slot name="supporting-text-end">{{ supportingTextEnd }}</slot>
       </template>
     </MdFilledField>
   </span>
 </template>
 
 <script setup>
-import { ref, onBeforeMount, watch } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useSlots, watch } from 'vue';
 import MdTextFieldBase from './MdTextFieldBase.vue';
 import MdFilledField from '../field/MdFilledField.vue';
 
+const slots = useSlots();
+
 const props = defineProps({
-  disabled: { type: Boolean },
-  error: { type: Boolean },
-  label: { type: String },
-  populated: { type: Boolean },
-  required: { type: Boolean },
-  focused: { type: Boolean },
-  value: { type: String },
-  modelValue: { type: String },
+  autocomplete: { type: String, default: '' },
+  autofocus: { type: Boolean, default: false },
+  disabled: { type: Boolean, default: false },
+  error: { type: Boolean, default: false },
+  errorText: { type: String, default: '' },
+  form: { type: String, default: '' },
+  focused: { type: Boolean, default: false },
+  inputmode: { type: String, default: '' },
+  invalid: { type: Boolean, default: false },
+  label: { type: String, default: '' },
+  list: { type: String, default: '' },
+  max: { type: String, default: '' },
+  maxlength: { type: Number, default: undefined },
+  min: { type: String, default: '' },
+  minlength: { type: Number, default: undefined },
+  modelValue: { type: [String, Number], default: '' },
+  name: { type: String, default: '' },
+  pattern: { type: String, default: '' },
+  placeholder: { type: String, default: '' },
+  populated: { type: Boolean, default: false },
+  prefix: { type: String, default: '' },
+  readonly: { type: Boolean, default: false },
+  required: { type: Boolean, default: false },
+  step: { type: String, default: '' },
+  suffix: { type: String, default: '' },
+  supportingText: { type: String, default: '' },
+  supportingTextEnd: { type: String, default: '' },
+  type: { type: String, default: 'text' },
+  value: { type: [String, Number], default: '' },
 });
 
-const emit = defineEmits(['focus', 'blur', 'update:modelValue']);
+const emit = defineEmits(['focus', 'blur', 'input', 'change', 'invalid', 'select', 'keyup', 'keydown', 'update:modelValue']);
 
-const inputValue = ref('');
+const normalizeValue = (value) => (value === null || value === undefined ? '' : `${value}`);
+
+const inputValue = ref(normalizeValue(props.modelValue || props.value));
 const textFieldEl = ref(null);
+const initialValue = ref(inputValue.value);
+const isInputFocused = ref(false);
+const labelOffset = ref(0);
+let formEl = null;
+const hasInputValue = computed(() => inputValue.value !== '');
 
-onBeforeMount(() => {
-  inputValue.value = props.modelValue;
+const resolvedSupportingText = computed(() => {
+  if (props.error && props.errorText) {
+    return props.errorText;
+  }
+
+  return props.supportingText;
 });
+const ariaInvalid = computed(() => ((props.error || props.invalid) ? 'true' : ''));
+const showPrefix = computed(() => hasInputValue.value || isInputFocused.value || props.focused);
+const showPrefixSlot = computed(() => showPrefix.value && !!slots.prefix);
+const resolvedPrefix = computed(() => (showPrefix.value ? props.prefix : ''));
 
 watch(
   () => props.modelValue,
-  () => {
-    inputValue.value = props.modelValue;
+  (value) => {
+    inputValue.value = normalizeValue(value);
+  }
+);
+
+watch(
+  () => props.value,
+  (value) => {
+    if (props.modelValue !== undefined && props.modelValue !== null && props.modelValue !== '') {
+      return;
+    }
+
+    inputValue.value = normalizeValue(value);
   }
 );
 
 const onTextFieldInput = (ev) => {
   inputValue.value = ev.target.value;
   emit('update:modelValue', inputValue.value);
+  emit('input', inputValue.value);
+};
+
+const onTextFieldChange = (ev) => {
+  inputValue.value = ev.target.value;
+  emit('change', inputValue.value);
+};
+
+const onTextFieldFocus = (ev) => {
+  isInputFocused.value = true;
+  emit('focus', ev);
+};
+
+const onTextFieldBlur = (ev) => {
+  isInputFocused.value = false;
+  emit('blur', ev);
+};
+
+const onFormReset = () => {
+  inputValue.value = initialValue.value;
+  emit('update:modelValue', inputValue.value);
+};
+
+const updateLabelOffset = () => {
+  const prefixEl = textFieldEl.value?.getPrefixEl?.();
+  labelOffset.value = showPrefix.value && prefixEl ? prefixEl.offsetWidth : 0;
 };
 
 const onClick = () => {
-  const inputEl = textFieldEl.value.$el.querySelector('.md-text-field__input');
-  inputEl.focus();
+  textFieldEl.value?.focus?.();
 };
+
+const focus = () => textFieldEl.value?.focus?.();
+const blur = () => textFieldEl.value?.blur?.();
+const checkValidity = () => textFieldEl.value?.checkValidity?.();
+const reportValidity = () => textFieldEl.value?.reportValidity?.();
+const setCustomValidity = (message) => textFieldEl.value?.setCustomValidity?.(message);
+
+defineExpose({
+  focus,
+  blur,
+  checkValidity,
+  reportValidity,
+  setCustomValidity,
+});
+
+onMounted(() => {
+  initialValue.value = normalizeValue(props.modelValue || props.value);
+  const inputEl = textFieldEl.value?.getInputEl?.();
+  formEl = inputEl?.form || null;
+  formEl?.addEventListener('reset', onFormReset);
+  nextTick(updateLabelOffset);
+});
+
+onBeforeUnmount(() => {
+  formEl?.removeEventListener('reset', onFormReset);
+});
+
+watch([showPrefix, () => props.prefix, inputValue], async () => {
+  await nextTick();
+  updateLabelOffset();
+});
 </script>
 
 <style lang="scss">
@@ -73,6 +220,28 @@ $theme: tokens.md-comp-filled-text-field-values();
 
   .md-field--filled {
     width: 100%;
+
+    .md-field__content {
+      transform: translateY(6px);
+    }
+  }
+
+  .md-text-field__affix {
+    font-family: map.get($theme, input-text-font);
+    font-size: map.get($theme, input-text-size);
+    line-height: map.get($theme, input-text-line-height);
+    font-weight: map.get($theme, input-text-weight);
+    letter-spacing: map.get($theme, input-text-tracking);
+  }
+
+  .md-text-field__affix--prefix {
+    color: map.get($theme, input-text-prefix-color);
+    padding-inline-end: 2px;
+  }
+
+  .md-text-field__affix--suffix {
+    color: map.get($theme, input-text-suffix-color);
+    padding-inline-start: 2px;
   }
 }
 </style>

--- a/src/components/text-field/MdOutlinedTextField.vue
+++ b/src/components/text-field/MdOutlinedTextField.vue
@@ -1,55 +1,203 @@
 <template>
   <span class="md-outlined-text-field" @click="onClick">
-    <MdOutlinedField :label="label" :populated="!!inputValue" :error="error">
-      <MdTextFieldBase ref="textFieldEl" :value="inputValue" @input="onTextFieldInput" @focus="$emit('focus', $event)" @blur="$emit('blur', $event)" />
+    <MdOutlinedField :disabled="disabled" :label="label" :populated="!!inputValue" :error="error" :required="required" :style="{ '--md-field-label-offset': `${labelOffsetWithBase}px` }">
+      <MdTextFieldBase
+        ref="textFieldEl"
+        :autocomplete="autocomplete"
+        :autofocus="autofocus"
+        :disabled="disabled"
+        :form="form"
+        :inputmode="inputmode"
+        :list="list"
+        :max="max"
+        :maxlength="maxlength"
+        :min="min"
+        :minlength="minlength"
+        :name="name"
+        :pattern="pattern"
+        :placeholder="placeholder"
+        :prefix="resolvedPrefix"
+        :readonly="readonly"
+        :required="required"
+        :step="step"
+        :suffix="suffix"
+        :type="type"
+        :value="inputValue"
+        :aria-invalid="ariaInvalid"
+        @input="onTextFieldInput"
+        @change="onTextFieldChange"
+        @focus="onTextFieldFocus"
+        @blur="onTextFieldBlur"
+        @select="$emit('select', $event)"
+        @keyup="$emit('keyup', $event)"
+        @keydown="$emit('keydown', $event)"
+        @invalid="$emit('invalid', $event)"
+      >
+        <template v-if="showPrefixSlot" #prefix>
+          <slot name="prefix" />
+        </template>
+        <template v-if="slots.suffix" #suffix>
+          <slot name="suffix" />
+        </template>
+      </MdTextFieldBase>
+
       <template #supporting-text>
-        <slot name="supporting-text" />
+        <slot name="supporting-text">{{ resolvedSupportingText }}</slot>
+      </template>
+      <template #supporting-text-end>
+        <slot name="supporting-text-end">{{ supportingTextEnd }}</slot>
       </template>
     </MdOutlinedField>
   </span>
 </template>
 
 <script setup>
-import { ref, onBeforeMount, watch } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useSlots, watch } from 'vue';
 import MdTextFieldBase from './MdTextFieldBase.vue';
 import MdOutlinedField from '../field/MdOutlinedField.vue';
 
+const slots = useSlots();
+
 const props = defineProps({
-  disabled: { type: Boolean },
-  error: { type: Boolean },
-  label: { type: String },
-  populated: { type: Boolean },
-  required: { type: Boolean },
-  focused: { type: Boolean },
-  value: { type: String },
-  modelValue: { type: String },
+  autocomplete: { type: String, default: '' },
+  autofocus: { type: Boolean, default: false },
+  disabled: { type: Boolean, default: false },
+  error: { type: Boolean, default: false },
+  errorText: { type: String, default: '' },
+  form: { type: String, default: '' },
+  focused: { type: Boolean, default: false },
+  inputmode: { type: String, default: '' },
+  invalid: { type: Boolean, default: false },
+  label: { type: String, default: '' },
+  list: { type: String, default: '' },
+  max: { type: String, default: '' },
+  maxlength: { type: Number, default: undefined },
+  min: { type: String, default: '' },
+  minlength: { type: Number, default: undefined },
+  modelValue: { type: [String, Number], default: '' },
+  name: { type: String, default: '' },
+  pattern: { type: String, default: '' },
+  placeholder: { type: String, default: '' },
+  populated: { type: Boolean, default: false },
+  prefix: { type: String, default: '' },
+  readonly: { type: Boolean, default: false },
+  required: { type: Boolean, default: false },
+  step: { type: String, default: '' },
+  suffix: { type: String, default: '' },
+  supportingText: { type: String, default: '' },
+  supportingTextEnd: { type: String, default: '' },
+  type: { type: String, default: 'text' },
+  value: { type: [String, Number], default: '' },
 });
 
-const emit = defineEmits(['focus', 'blur', 'update:modelValue']);
+const emit = defineEmits(['focus', 'blur', 'input', 'change', 'invalid', 'select', 'keyup', 'keydown', 'update:modelValue']);
 
-const inputValue = ref('');
+const normalizeValue = (value) => (value === null || value === undefined ? '' : `${value}`);
+
+const inputValue = ref(normalizeValue(props.modelValue || props.value));
 const textFieldEl = ref(null);
+const initialValue = ref(inputValue.value);
+const isInputFocused = ref(false);
+const labelOffset = ref(0);
+let formEl = null;
+const hasInputValue = computed(() => inputValue.value !== '');
 
-onBeforeMount(() => {
-  inputValue.value = props.modelValue;
+const resolvedSupportingText = computed(() => {
+  if (props.error && props.errorText) {
+    return props.errorText;
+  }
+
+  return props.supportingText;
 });
+const ariaInvalid = computed(() => ((props.error || props.invalid) ? 'true' : ''));
+const showPrefix = computed(() => hasInputValue.value || isInputFocused.value || props.focused);
+const showPrefixSlot = computed(() => showPrefix.value && !!slots.prefix);
+const resolvedPrefix = computed(() => (showPrefix.value ? props.prefix : ''));
+const labelOffsetWithBase = computed(() => labelOffset.value + 8);
 
 watch(
   () => props.modelValue,
-  () => {
-    inputValue.value = props.modelValue;
+  (value) => {
+    inputValue.value = normalizeValue(value);
+  }
+);
+
+watch(
+  () => props.value,
+  (value) => {
+    if (props.modelValue !== undefined && props.modelValue !== null && props.modelValue !== '') {
+      return;
+    }
+
+    inputValue.value = normalizeValue(value);
   }
 );
 
 const onTextFieldInput = (ev) => {
   inputValue.value = ev.target.value;
   emit('update:modelValue', inputValue.value);
+  emit('input', inputValue.value);
+};
+
+const onTextFieldChange = (ev) => {
+  inputValue.value = ev.target.value;
+  emit('change', inputValue.value);
+};
+
+const onTextFieldFocus = (ev) => {
+  isInputFocused.value = true;
+  emit('focus', ev);
+};
+
+const onTextFieldBlur = (ev) => {
+  isInputFocused.value = false;
+  emit('blur', ev);
+};
+
+const onFormReset = () => {
+  inputValue.value = initialValue.value;
+  emit('update:modelValue', inputValue.value);
+};
+
+const updateLabelOffset = () => {
+  const prefixEl = textFieldEl.value?.getPrefixEl?.();
+  labelOffset.value = showPrefix.value && prefixEl ? prefixEl.offsetWidth : 0;
 };
 
 const onClick = () => {
-  const inputEl = textFieldEl.value.$el.querySelector('.md-text-field__input');
-  inputEl.focus();
+  textFieldEl.value?.focus?.();
 };
+
+const focus = () => textFieldEl.value?.focus?.();
+const blur = () => textFieldEl.value?.blur?.();
+const checkValidity = () => textFieldEl.value?.checkValidity?.();
+const reportValidity = () => textFieldEl.value?.reportValidity?.();
+const setCustomValidity = (message) => textFieldEl.value?.setCustomValidity?.(message);
+
+defineExpose({
+  focus,
+  blur,
+  checkValidity,
+  reportValidity,
+  setCustomValidity,
+});
+
+onMounted(() => {
+  initialValue.value = normalizeValue(props.modelValue || props.value);
+  const inputEl = textFieldEl.value?.getInputEl?.();
+  formEl = inputEl?.form || null;
+  formEl?.addEventListener('reset', onFormReset);
+  nextTick(updateLabelOffset);
+});
+
+onBeforeUnmount(() => {
+  formEl?.removeEventListener('reset', onFormReset);
+});
+
+watch([showPrefix, () => props.prefix, inputValue], async () => {
+  await nextTick();
+  updateLabelOffset();
+});
 </script>
 
 <style lang="scss">
@@ -72,6 +220,24 @@ $theme: tokens.md-comp-outlined-text-field-values();
   }
   .md-field--outlined {
     width: 100%;
+  }
+
+  .md-text-field__affix {
+    font-family: map.get($theme, input-text-font);
+    font-size: map.get($theme, input-text-size);
+    line-height: map.get($theme, input-text-line-height);
+    font-weight: map.get($theme, input-text-weight);
+    letter-spacing: map.get($theme, input-text-tracking);
+  }
+
+  .md-text-field__affix--prefix {
+    color: map.get($theme, input-text-prefix-color);
+    padding-inline-end: 2px;
+  }
+
+  .md-text-field__affix--suffix {
+    color: map.get($theme, input-text-suffix-color);
+    padding-inline-start: 2px;
   }
 }
 </style>

--- a/src/components/text-field/MdTextFieldBase.vue
+++ b/src/components/text-field/MdTextFieldBase.vue
@@ -1,37 +1,102 @@
 <template>
   <span class="md-text-field">
-    <input
-      class="md-text-field__input"
-      :disabled="disabled"
-      :placeholder="placeholder"
-      :readonly="readonly"
-      :required="required"
-      :type="type"
-      :value="value"
-      @change="$emit('change', $event)"
-      @input="$emit('input', $event)"
-      @select="$emit('select', $event)"
-      @focus="$emit('focus', $event)"
-      @blur="$emit('blur', $event)"
-      @keyup="$emit('keyup', $event)"
-      @keydown="$emit('keydown', $event)"
-    />
+    <span class="md-text-field__input-wrapper">
+      <span v-if="hasPrefix" ref="prefixEl" class="md-text-field__affix md-text-field__affix--prefix">
+        <slot name="prefix">{{ prefix }}</slot>
+      </span>
+
+      <input
+        ref="inputEl"
+        class="md-text-field__input"
+        :autocomplete="autocomplete || undefined"
+        :autofocus="autofocus"
+        :disabled="disabled"
+        :form="form || undefined"
+        :inputmode="inputmode || undefined"
+        :list="list || undefined"
+        :max="max || undefined"
+        :maxlength="maxlength"
+        :min="min || undefined"
+        :minlength="minlength"
+        :name="name || undefined"
+        :pattern="pattern || undefined"
+        :placeholder="placeholder"
+        :readonly="readonly"
+        :required="required"
+        :step="step || undefined"
+        :type="type"
+        :value="value"
+        :aria-invalid="ariaInvalid || undefined"
+        @change="$emit('change', $event)"
+        @input="$emit('input', $event)"
+        @select="$emit('select', $event)"
+        @focus="$emit('focus', $event)"
+        @blur="$emit('blur', $event)"
+        @keyup="$emit('keyup', $event)"
+        @keydown="$emit('keydown', $event)"
+        @invalid="$emit('invalid', $event)"
+      />
+
+      <span v-if="hasSuffix" class="md-text-field__affix md-text-field__affix--suffix">
+        <slot name="suffix">{{ suffix }}</slot>
+      </span>
+    </span>
   </span>
 </template>
 
 <script setup>
-import { defineProps } from 'vue';
+import { computed, ref, useSlots } from 'vue';
 
-defineProps({
-  disabled: { type: Boolean },
-  error: { type: Boolean },
-  label: { type: String },
-  required: { type: Boolean },
-  value: { type: String, default: '' },
+defineEmits(['change', 'input', 'select', 'focus', 'blur', 'keyup', 'keydown', 'invalid']);
+
+const slots = useSlots();
+
+const props = defineProps({
+  ariaInvalid: { type: String, default: '' },
+  autocomplete: { type: String, default: '' },
+  autofocus: { type: Boolean, default: false },
+  disabled: { type: Boolean, default: false },
+  form: { type: String, default: '' },
+  inputmode: { type: String, default: '' },
+  list: { type: String, default: '' },
+  max: { type: String, default: '' },
+  maxlength: { type: Number, default: undefined },
+  min: { type: String, default: '' },
+  minlength: { type: Number, default: undefined },
   name: { type: String, default: '' },
+  pattern: { type: String, default: '' },
   placeholder: { type: String, default: '' },
-  readonly: { type: Boolean },
+  prefix: { type: String, default: '' },
+  readonly: { type: Boolean, default: false },
+  required: { type: Boolean, default: false },
+  step: { type: String, default: '' },
+  suffix: { type: String, default: '' },
   type: { type: String, default: 'text' },
+  value: { type: [String, Number], default: '' },
+});
+
+const hasPrefix = computed(() => !!props.prefix || !!slots.prefix);
+const hasSuffix = computed(() => !!props.suffix || !!slots.suffix);
+
+const inputEl = ref(null);
+const prefixEl = ref(null);
+
+const getInputEl = () => inputEl.value;
+const getPrefixEl = () => prefixEl.value;
+const focus = () => inputEl.value?.focus();
+const blur = () => inputEl.value?.blur();
+const checkValidity = () => inputEl.value?.checkValidity();
+const reportValidity = () => inputEl.value?.reportValidity();
+const setCustomValidity = (message) => inputEl.value?.setCustomValidity(message || '');
+
+defineExpose({
+  getInputEl,
+  getPrefixEl,
+  focus,
+  blur,
+  checkValidity,
+  reportValidity,
+  setCustomValidity,
 });
 </script>
 
@@ -41,8 +106,19 @@ defineProps({
   outline: none;
   width: 100%;
 
+  &__input-wrapper {
+    display: flex;
+    width: 100%;
+    align-items: center;
+  }
+
   &__field {
     cursor: text;
+  }
+
+  &__affix {
+    flex-shrink: 0;
+    white-space: nowrap;
   }
 
   &__input {
@@ -50,9 +126,10 @@ defineProps({
     background: none;
     border: none;
     color: currentColor;
+    flex: 1 1 auto;
+    min-width: 0;
     outline: none;
     padding: 0;
-    width: 100%;
 
     // Remove built-in datepicker icon on Chrome
     &::-webkit-calendar-picker-indicator {

--- a/stories/components/text-field/MdFilledTextField.stories.js
+++ b/stories/components/text-field/MdFilledTextField.stories.js
@@ -17,4 +17,17 @@ const Template = (args) => ({
 export const FilledTextField = Template.bind({});
 FilledTextField.args = {
   label: 'Filled Label',
+  modelValue: '',
+  name: 'filled-text-field',
+  supportingText: 'Supporting text',
+  prefix: '$',
+  suffix: 'USD',
+};
+
+export const FilledTextFieldError = Template.bind({});
+FilledTextFieldError.args = {
+  label: 'Filled Label',
+  modelValue: '',
+  error: true,
+  errorText: 'Please enter a valid value',
 };

--- a/stories/components/text-field/MdOutlinedTextField.stories.js
+++ b/stories/components/text-field/MdOutlinedTextField.stories.js
@@ -24,4 +24,17 @@ export const OutlinedTextField = Template.bind({});
 // More on args: https://storybook.js.org/docs/vue/writing-stories/args
 OutlinedTextField.args = {
   label: 'Outlined Label',
+  modelValue: '',
+  name: 'outlined-text-field',
+  supportingText: 'Supporting text',
+  prefix: '@',
+  suffix: '.com',
+};
+
+export const OutlinedTextFieldError = Template.bind({});
+OutlinedTextFieldError.args = {
+  label: 'Outlined Label',
+  modelValue: '',
+  error: true,
+  errorText: 'Please enter a valid value',
 };

--- a/tests/unit/components/text-field/MdFilledTextField.spec.js
+++ b/tests/unit/components/text-field/MdFilledTextField.spec.js
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import MdFilledTextField from '@/components/text-field/MdFilledTextField.vue';
+
+describe('MdFilledTextField', () => {
+  it('renders supporting text and swaps to error text in error state', async () => {
+    const wrapper = mount(MdFilledTextField, {
+      props: {
+        label: 'Amount',
+        supportingText: 'Enter amount',
+      },
+    });
+
+    expect(wrapper.text()).toContain('Enter amount');
+
+    await wrapper.setProps({ error: true, errorText: 'Invalid amount' });
+    expect(wrapper.text()).toContain('Invalid amount');
+  });
+
+  it('renders prefix and suffix props when value is populated', () => {
+    const wrapper = mount(MdFilledTextField, {
+      props: {
+        label: 'Amount',
+        modelValue: '10',
+        prefix: '$',
+        suffix: 'USD',
+      },
+    });
+
+    expect(wrapper.text()).toContain('$');
+    expect(wrapper.text()).toContain('USD');
+  });
+
+  it('does not render prefix when value is empty', () => {
+    const wrapper = mount(MdFilledTextField, {
+      props: {
+        label: 'Amount',
+        modelValue: '',
+        prefix: '$',
+      },
+    });
+
+    expect(wrapper.text()).not.toContain('$');
+  });
+
+  it('renders prefix on focus even when value is empty', async () => {
+    const wrapper = mount(MdFilledTextField, {
+      props: {
+        label: 'Amount',
+        modelValue: '',
+        prefix: '$',
+      },
+    });
+
+    expect(wrapper.text()).not.toContain('$');
+
+    const input = wrapper.get('input');
+    await input.trigger('focus');
+    expect(wrapper.text()).toContain('$');
+
+    await input.trigger('blur');
+    expect(wrapper.text()).not.toContain('$');
+  });
+
+  it('emits v-model/input and supports reset from associated form', async () => {
+    const form = document.createElement('form');
+    form.id = 'price-form';
+    document.body.appendChild(form);
+
+    const wrapper = mount(MdFilledTextField, {
+      attachTo: document.body,
+      props: {
+        label: 'Amount',
+        form: 'price-form',
+        name: 'amount',
+        modelValue: '10',
+      },
+    });
+
+    const input = wrapper.get('input');
+    expect(input.attributes('name')).toBe('amount');
+
+    await input.setValue('25');
+
+    const emittedUpdates = wrapper.emitted('update:modelValue') || [];
+    expect(emittedUpdates[0]).toEqual(['25']);
+    expect(wrapper.emitted('input')?.[0]).toEqual(['25']);
+
+    form.dispatchEvent(new Event('reset'));
+    await nextTick();
+
+    const latestUpdate = (wrapper.emitted('update:modelValue') || []).at(-1);
+    expect(latestUpdate).toEqual(['10']);
+
+    wrapper.unmount();
+    form.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- expand text field API surface (form/validity attrs, events, exposed methods)
- add error/supporting text behavior parity for filled + outlined
- align prefix/suffix behavior with Material patterns (visibility, spacing, label offset)
- fix field content spacing when start/end slots are empty
- refine outlined default label offset and filled content stability on focus

## Tests
- npm test
- npm run build-storybook

## Scope
- W2-04 TextField API Expansion