### PR TITLE
feat: checkbox/radio/switch form parity (W2-05)

### DIFF
--- a/src/components/checkbox/MdCheckbox.vue
+++ b/src/components/checkbox/MdCheckbox.vue
@@ -1,11 +1,24 @@
 <template>
   <div
     class="md-checkbox"
-    :class="{ 'md-checkbox--disabled': disabled, 'md-checkbox--checked': _checked, 'md-checkbox--indeterminate': _indeterminate, 'md-checkbox--focused': focused }"
-    @click="toggle"
+    :class="{ 'md-checkbox--disabled': disabled, 'md-checkbox--checked': _checked, 'md-checkbox--indeterminate': _indeterminate }"
   >
     <MdRipple />
-    <input type="checkbox" :name="name" @input="onInput" @change="onInputChange" @focus="onFocus" @blur="onBlur" />
+    <input
+      ref="inputEl"
+      type="checkbox"
+      :checked="_checked"
+      :disabled="disabled"
+      :name="name || undefined"
+      :value="value"
+      :form="form || undefined"
+      :required="required"
+      :readonly="readonly"
+      @input="onInput"
+      @change="onInputChange"
+      @focus="onFocus"
+      @blur="onBlur"
+    />
     <div class="md-checkbox__background">
       <svg class="md-checkbox__checkmark" viewBox="0 0 24 24" aria-hidden="true">
         <path class="md-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"></path>
@@ -16,62 +29,151 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import MdRipple from '../ripple/MdRipple.vue';
 
-const emit = defineEmits(['update:model-value']);
+const emit = defineEmits(['update:modelValue', 'update:model-value', 'input', 'change', 'focus', 'blur']);
 
+const inputEl = ref(null);
 const _checked = ref(false);
 const _indeterminate = ref(false);
-const focused = ref(false);
+const initialChecked = ref(false);
+const initialIndeterminate = ref(false);
+let formEl = null;
 
 const props = defineProps({
-  disabled: {
-    type: Boolean,
-  },
-  modelValue: {
-    type: Boolean,
-  },
-  indeterminate: {
-    type: Boolean,
-  },
-  name: {
-    type: String,
-  },
+  checked: { type: Boolean, default: undefined },
+  disabled: { type: Boolean, default: false },
+  form: { type: String, default: '' },
+  indeterminate: { type: Boolean, default: false },
+  modelValue: { type: Boolean, default: undefined },
+  name: { type: String, default: '' },
+  readonly: { type: Boolean, default: false },
+  required: { type: Boolean, default: false },
+  value: { type: [String, Number], default: 'on' },
 });
 
-const onInput = () => {};
-const onFocus = () => {
-  focused.value = true;
+const resolveChecked = () => {
+  if (props.modelValue !== undefined) {
+    return !!props.modelValue;
+  }
+
+  if (props.checked !== undefined) {
+    return !!props.checked;
+  }
+
+  return false;
 };
-const onBlur = () => {
-  focused.value = false;
+
+const syncIndeterminateToInput = () => {
+  if (inputEl.value) {
+    inputEl.value.indeterminate = _indeterminate.value;
+  }
 };
-const onInputChange = () => {};
+
+const emitCheckedUpdate = () => {
+  emit('update:modelValue', _checked.value);
+  emit('update:model-value', _checked.value);
+};
+
+const onInput = (ev) => {
+  if (props.disabled || props.readonly) {
+    return;
+  }
+
+  emit('input', ev.target.checked);
+};
+
+const onFocus = (ev) => {
+  emit('focus', ev);
+};
+
+const onBlur = (ev) => {
+  emit('blur', ev);
+};
+
+const onInputChange = (ev) => {
+  if (props.disabled || props.readonly) {
+    ev.target.checked = _checked.value;
+    syncIndeterminateToInput();
+    return;
+  }
+
+  _checked.value = ev.target.checked;
+  _indeterminate.value = false;
+  syncIndeterminateToInput();
+  emitCheckedUpdate();
+  emit('change', _checked.value);
+};
 
 watch(
   () => props.modelValue,
   (newValue) => {
-    _checked.value = newValue;
-    emit('update:model-value', _checked.value);
+    if (newValue === undefined) {
+      return;
+    }
+
+    _checked.value = !!newValue;
   },
-  { immediate: true }
+  { immediate: true },
 );
+
+watch(
+  () => props.checked,
+  (newValue) => {
+    if (props.modelValue !== undefined || newValue === undefined) {
+      return;
+    }
+
+    _checked.value = !!newValue;
+  },
+  { immediate: true },
+);
+
 watch(
   () => props.indeterminate,
   (newValue) => {
     _indeterminate.value = newValue;
+    syncIndeterminateToInput();
   },
-  { immediate: true }
+  { immediate: true },
 );
 
-const toggle = () => {
-  if (!props.disabled) {
-    _checked.value = !_checked.value;
-    _indeterminate.value = false;
-    emit('update:model-value', _checked.value);
-  }
+const onFormReset = () => {
+  _checked.value = initialChecked.value;
+  _indeterminate.value = initialIndeterminate.value;
+  syncIndeterminateToInput();
+  emitCheckedUpdate();
 };
+
+const focus = () => inputEl.value?.focus();
+const blur = () => inputEl.value?.blur();
+const checkValidity = () => inputEl.value?.checkValidity();
+const reportValidity = () => inputEl.value?.reportValidity();
+const setCustomValidity = (message) => inputEl.value?.setCustomValidity(message || '');
+const getInputEl = () => inputEl.value;
+
+defineExpose({
+  focus,
+  blur,
+  checkValidity,
+  reportValidity,
+  setCustomValidity,
+  getInputEl,
+});
+
+onMounted(() => {
+  _checked.value = resolveChecked();
+  initialChecked.value = _checked.value;
+  initialIndeterminate.value = _indeterminate.value;
+  syncIndeterminateToInput();
+  formEl = inputEl.value?.form || null;
+  formEl?.addEventListener('reset', onFormReset);
+});
+
+onBeforeUnmount(() => {
+  formEl?.removeEventListener('reset', onFormReset);
+});
 </script>
 
 <style lang="scss">
@@ -83,9 +185,10 @@ $theme: tokens.md-comp-checkbox-values();
 
 .md-checkbox {
   $this: &;
+  --md-checkbox-touch-target-size: 48px;
   position: relative;
-  width: 48px;
-  height: 48px;
+  width: var(--md-checkbox-touch-target-size);
+  height: var(--md-checkbox-touch-target-size);
   border-radius: map.get($theme, state-layer-shape);
   align-items: center;
   border: none;
@@ -99,9 +202,21 @@ $theme: tokens.md-comp-checkbox-values();
     position: absolute;
     inset: 0;
     appearance: none;
-    width: 0;
-    height: 0;
+    outline: none;
+    border: none;
+    background: transparent;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    cursor: inherit;
     z-index: 1;
+    box-shadow: none;
+
+    &:focus,
+    &:focus-visible {
+      outline: none;
+      box-shadow: none;
+    }
   }
 
   &__background {
@@ -150,6 +265,13 @@ $theme: tokens.md-comp-checkbox-values();
     }
   }
 
+  .md-ripple {
+    width: map.get($theme, state-layer-size);
+    height: map.get($theme, state-layer-size);
+    inset: 0;
+    margin: auto;
+  }
+
   &--indeterminate {
     #{$this}__background {
       background-color: map.get($theme, selected-container-color);
@@ -181,6 +303,15 @@ $theme: tokens.md-comp-checkbox-values();
         }
       }
     }
+
+    .md-ripple {
+      --md-ripple-hover-state-layer-color: #{map.get($theme, selected-hover-state-layer-color)};
+      --md-ripple-focus-state-layer-color: #{map.get($theme, selected-focus-state-layer-color)};
+      --md-ripple-pressed-state-layer-color: #{map.get($theme, selected-pressed-state-layer-color)};
+      --md-ripple-hover-state-layer-opacity: #{map.get($theme, selected-hover-state-layer-opacity)};
+      --md-ripple-focus-state-layer-opacity: #{map.get($theme, selected-focus-state-layer-opacity)};
+      --md-ripple-pressed-state-layer-opacity: #{map.get($theme, selected-pressed-state-layer-opacity)};
+    }
   }
 
   &--checked {
@@ -194,12 +325,15 @@ $theme: tokens.md-comp-checkbox-values();
         }
       }
     }
-  }
 
-  &--focused {
-    border-width: map.get($theme, unselected-focus-outline-width);
-    border-color: map.get($theme, unselected-focus-outline-color);
-    border-style: solid;
+    .md-ripple {
+      --md-ripple-hover-state-layer-color: #{map.get($theme, selected-hover-state-layer-color)};
+      --md-ripple-focus-state-layer-color: #{map.get($theme, selected-focus-state-layer-color)};
+      --md-ripple-pressed-state-layer-color: #{map.get($theme, selected-pressed-state-layer-color)};
+      --md-ripple-hover-state-layer-opacity: #{map.get($theme, selected-hover-state-layer-opacity)};
+      --md-ripple-focus-state-layer-opacity: #{map.get($theme, selected-focus-state-layer-opacity)};
+      --md-ripple-pressed-state-layer-opacity: #{map.get($theme, selected-pressed-state-layer-opacity)};
+    }
   }
 
   &--disabled {

--- a/src/components/radio/MdRadio.vue
+++ b/src/components/radio/MdRadio.vue
@@ -1,7 +1,20 @@
 <template>
   <div class="md-radio" :class="{ 'md-radio--disabled': disabled, 'md-radio--checked': checked }">
     <MdRipple />
-    <input :checked="checked" :disabled="disabled" :name="name" type="radio" :value="value" @change="toggle" />
+    <input
+      ref="inputEl"
+      :checked="checked"
+      :disabled="disabled"
+      :name="name || undefined"
+      type="radio"
+      :value="value"
+      :form="form || undefined"
+      :required="required"
+      @input="onInput"
+      @change="onChange"
+      @focus="$emit('focus', $event)"
+      @blur="$emit('blur', $event)"
+    />
     <div class="md-radio__background">
       <div class="md-radio__outer-circle"></div>
       <div class="md-radio__inner-circle"></div>
@@ -10,33 +23,110 @@
 </template>
 
 <script setup>
-import { computed } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import MdRipple from '../ripple/MdRipple.vue';
 
-const emit = defineEmits(['update:modelValue']);
+const emit = defineEmits(['update:modelValue', 'input', 'change', 'focus', 'blur']);
 
 const props = defineProps({
-  disabled: {
-    type: Boolean,
-  },
-  name: {
-    type: String,
-  },
-  value: {
-    type: String,
-  },
-  modelValue: {
-    type: String,
-  },
+  checked: { type: Boolean, default: undefined },
+  disabled: { type: Boolean, default: false },
+  form: { type: String, default: '' },
+  modelValue: { type: [String, Number, Boolean], default: undefined },
+  name: { type: String, default: '' },
+  required: { type: Boolean, default: false },
+  value: { type: [String, Number, Boolean], default: '' },
 });
 
-const toggle = () => {
-  if (!props.disabled) {
+const inputEl = ref(null);
+const internalChecked = ref(false);
+const initialChecked = ref(false);
+let formEl = null;
+
+const resolveChecked = () => {
+  if (props.modelValue !== undefined) {
+    return props.modelValue === props.value;
+  }
+
+  return !!props.checked;
+};
+
+watch(
+  () => props.modelValue,
+  () => {
+    internalChecked.value = resolveChecked();
+  },
+  { immediate: true },
+);
+
+watch(
+  () => props.checked,
+  () => {
+    if (props.modelValue !== undefined) {
+      return;
+    }
+
+    internalChecked.value = resolveChecked();
+  },
+  { immediate: true },
+);
+
+const onInput = (ev) => {
+  if (props.disabled) {
+    return;
+  }
+
+  emit('input', ev.target.checked ? props.value : null);
+};
+
+const onChange = (ev) => {
+  if (props.disabled) {
+    ev.target.checked = internalChecked.value;
+    return;
+  }
+
+  internalChecked.value = ev.target.checked;
+  if (internalChecked.value) {
+    emit('update:modelValue', props.value);
+    emit('change', props.value);
+  }
+};
+
+const onFormReset = () => {
+  internalChecked.value = initialChecked.value;
+  if (internalChecked.value) {
     emit('update:modelValue', props.value);
   }
 };
 
-const checked = computed(() => props.modelValue === props.value);
+const checked = computed(() => internalChecked.value);
+
+const focus = () => inputEl.value?.focus();
+const blur = () => inputEl.value?.blur();
+const checkValidity = () => inputEl.value?.checkValidity();
+const reportValidity = () => inputEl.value?.reportValidity();
+const setCustomValidity = (message) => inputEl.value?.setCustomValidity(message || '');
+const getInputEl = () => inputEl.value;
+
+defineExpose({
+  focus,
+  blur,
+  checkValidity,
+  reportValidity,
+  setCustomValidity,
+  getInputEl,
+});
+
+onMounted(() => {
+  internalChecked.value = resolveChecked();
+  initialChecked.value = internalChecked.value;
+  formEl = inputEl.value?.form || null;
+  formEl?.addEventListener('reset', onFormReset);
+});
+
+onBeforeUnmount(() => {
+  formEl?.removeEventListener('reset', onFormReset);
+});
 </script>
 
 <style lang="scss">

--- a/src/components/ripple/MdRipple.vue
+++ b/src/components/ripple/MdRipple.vue
@@ -37,8 +37,8 @@ const surfaceClasses = computed(() => ({
 }));
 
 onMounted(() => {
-  mdRipple.value.parentElement.addEventListener('focus', handleRippleFocus);
-  mdRipple.value.parentElement.addEventListener('blur', handleRippleBlur);
+  mdRipple.value.parentElement.addEventListener('focusin', handleRippleFocus);
+  mdRipple.value.parentElement.addEventListener('focusout', handleRippleBlur);
   mdRipple.value.parentElement.addEventListener('mousedown', handleRippleActivate);
   mdRipple.value.parentElement.addEventListener('mouseenter', handleRippleMouseEnter);
   mdRipple.value.parentElement.addEventListener('mouseleave', handleRippleMouseLeave);
@@ -49,8 +49,8 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
-  mdRipple.value.parentElement.removeEventListener('focus', handleRippleFocus);
-  mdRipple.value.parentElement.removeEventListener('blur', handleRippleBlur);
+  mdRipple.value.parentElement.removeEventListener('focusin', handleRippleFocus);
+  mdRipple.value.parentElement.removeEventListener('focusout', handleRippleBlur);
   mdRipple.value.parentElement.removeEventListener('mousedown', handleRippleActivate);
   mdRipple.value.parentElement.removeEventListener('mouseenter', handleRippleMouseEnter);
   mdRipple.value.parentElement.removeEventListener('mouseleave', handleRippleMouseLeave);
@@ -219,6 +219,11 @@ function handleRippleDeactivate() {
     &--hovered::before {
       opacity: var(--md-ripple-hover-state-layer-opacity, 0.08);
       background-color: var(--md-ripple-hover-state-layer-color, black);
+    }
+
+    &--focused::before {
+      opacity: var(--md-ripple-focus-state-layer-opacity, 0.12);
+      background-color: var(--md-ripple-focus-state-layer-color, black);
     }
 
     &--pressed::after {

--- a/src/components/switch/MdSwitch.vue
+++ b/src/components/switch/MdSwitch.vue
@@ -1,6 +1,20 @@
 <template>
-  <div class="md-switch" :class="{ 'md-switch--disabled': disabled, 'md-switch--checked': _checked }" @click="toggle">
-    <input :checked="_checked" :disabled="disabled" :name="name" type="checkbox" :value="value" @change="toggle" />
+  <div class="md-switch" :class="{ 'md-switch--disabled': disabled, 'md-switch--checked': _checked }">
+    <input
+      ref="inputEl"
+      :checked="_checked"
+      :disabled="disabled"
+      :name="name || undefined"
+      type="checkbox"
+      :value="value"
+      :form="form || undefined"
+      :required="required"
+      :readonly="readonly"
+      @input="onInput"
+      @change="onInputChange"
+      @focus="$emit('focus', $event)"
+      @blur="$emit('blur', $event)"
+    />
     <div class="md-switch__track">
       <div class="md-switch__handle-container">
         <div class="md-switch__handle"></div>
@@ -10,34 +24,46 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
 
 const _checked = ref(false);
+const inputEl = ref(null);
+const initialChecked = ref(false);
+let formEl = null;
 
-const emit = defineEmits(['update:modelValue']);
+const emit = defineEmits(['update:modelValue', 'input', 'change', 'focus', 'blur']);
 
 const props = defineProps({
-  disabled: {
-    type: Boolean,
-  },
-  name: {
-    type: String,
-  },
-  value: {
-    type: String,
-  },
-  modelValue: {
-    type: Boolean,
-  },
-  checked: {
-    type: Boolean,
-  },
+  checked: { type: Boolean, default: undefined },
+  disabled: { type: Boolean, default: false },
+  form: { type: String, default: '' },
+  modelValue: { type: Boolean, default: undefined },
+  name: { type: String, default: '' },
+  readonly: { type: Boolean, default: false },
+  required: { type: Boolean, default: false },
+  value: { type: [String, Number], default: 'on' },
 });
+
+const resolveChecked = () => {
+  if (props.modelValue !== undefined) {
+    return !!props.modelValue;
+  }
+
+  if (props.checked !== undefined) {
+    return !!props.checked;
+  }
+
+  return false;
+};
 
 watch(
   () => props.checked,
   (newValue) => {
-    _checked.value = newValue;
+    if (props.modelValue !== undefined || newValue === undefined) {
+      return;
+    }
+
+    _checked.value = !!newValue;
   },
   { immediate: true },
 );
@@ -45,17 +71,65 @@ watch(
 watch(
   () => props.modelValue,
   (newValue) => {
-    _checked.value = newValue;
+    if (newValue === undefined) {
+      return;
+    }
+
+    _checked.value = !!newValue;
   },
   { immediate: true },
 );
 
-const toggle = () => {
-  if (!props.disabled) {
-    _checked.value = !_checked.value;
-    emit('update:modelValue', _checked.value);
+const onInput = (ev) => {
+  if (props.disabled || props.readonly) {
+    return;
   }
+
+  emit('input', ev.target.checked);
 };
+
+const onInputChange = (ev) => {
+  if (props.disabled || props.readonly) {
+    ev.target.checked = _checked.value;
+    return;
+  }
+
+  _checked.value = ev.target.checked;
+  emit('update:modelValue', _checked.value);
+  emit('change', _checked.value);
+};
+
+const onFormReset = () => {
+  _checked.value = initialChecked.value;
+  emit('update:modelValue', _checked.value);
+};
+
+const focus = () => inputEl.value?.focus();
+const blur = () => inputEl.value?.blur();
+const checkValidity = () => inputEl.value?.checkValidity();
+const reportValidity = () => inputEl.value?.reportValidity();
+const setCustomValidity = (message) => inputEl.value?.setCustomValidity(message || '');
+const getInputEl = () => inputEl.value;
+
+defineExpose({
+  focus,
+  blur,
+  checkValidity,
+  reportValidity,
+  setCustomValidity,
+  getInputEl,
+});
+
+onMounted(() => {
+  _checked.value = resolveChecked();
+  initialChecked.value = _checked.value;
+  formEl = inputEl.value?.form || null;
+  formEl?.addEventListener('reset', onFormReset);
+});
+
+onBeforeUnmount(() => {
+  formEl?.removeEventListener('reset', onFormReset);
+});
 </script>
 
 <style lang="scss">
@@ -82,7 +156,15 @@ $theme: tokens.md-comp-switch-values();
   border-radius: map.get($theme, track-shape);
 
   input {
-    display: none;
+    position: absolute;
+    margin: 0;
+    padding: 0;
+    opacity: 0;
+    cursor: inherit;
+    z-index: 1;
+    block-size: 100%;
+    inline-size: 100%;
+    inset: 0;
   }
 
   &__track {

--- a/tests/unit/components/checkbox/MdCheckbox.spec.js
+++ b/tests/unit/components/checkbox/MdCheckbox.spec.js
@@ -1,0 +1,88 @@
+import { nextTick } from 'vue';
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import MdCheckbox from '@/components/checkbox/MdCheckbox.vue';
+
+describe('MdCheckbox', () => {
+  it('emits input/change and update:modelValue when toggled', async () => {
+    const wrapper = mount(MdCheckbox, {
+      props: {
+        modelValue: false,
+      },
+    });
+
+    await wrapper.get('input').setValue(true);
+
+    expect(wrapper.emitted('input')).toEqual([[true]]);
+    expect(wrapper.emitted('change')).toEqual([[true]]);
+    expect(wrapper.emitted('update:modelValue')).toEqual([[true]]);
+  });
+
+  it('serializes with form data when checked', async () => {
+    const form = document.createElement('form');
+    form.id = 'checkbox-form';
+    document.body.appendChild(form);
+
+    const wrapper = mount(MdCheckbox, {
+      attachTo: document.body,
+      props: {
+        checked: true,
+        form: 'checkbox-form',
+        name: 'terms',
+        value: 'yes',
+      },
+    });
+
+    await nextTick();
+
+    expect(new FormData(form).get('terms')).toBe('yes');
+
+    wrapper.unmount();
+    form.remove();
+  });
+
+  it('restores initial state on form reset', async () => {
+    const form = document.createElement('form');
+    form.id = 'checkbox-reset-form';
+    document.body.appendChild(form);
+
+    const wrapper = mount(MdCheckbox, {
+      attachTo: document.body,
+      props: {
+        checked: true,
+        form: 'checkbox-reset-form',
+        name: 'newsletter',
+      },
+    });
+
+    const input = wrapper.get('input');
+
+    await input.setValue(false);
+    expect(input.element.checked).toBe(false);
+
+    form.reset();
+    await nextTick();
+
+    expect(input.element.checked).toBe(true);
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([true]);
+
+    wrapper.unmount();
+    form.remove();
+  });
+
+  it('does not update when readonly', async () => {
+    const wrapper = mount(MdCheckbox, {
+      props: {
+        modelValue: true,
+        readonly: true,
+      },
+    });
+
+    const input = wrapper.get('input');
+    input.element.checked = false;
+    await input.trigger('change');
+
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+    expect(input.element.checked).toBe(true);
+  });
+});

--- a/tests/unit/components/radio/MdRadio.spec.js
+++ b/tests/unit/components/radio/MdRadio.spec.js
@@ -1,3 +1,4 @@
+import { defineComponent, nextTick } from 'vue';
 import { describe, expect, it } from 'vitest';
 import { mount } from '@vue/test-utils';
 import MdRadio from '@/components/radio/MdRadio.vue';
@@ -22,9 +23,10 @@ describe('MdRadio', () => {
       },
     });
 
-    await wrapper.get('input').trigger('change');
+    await wrapper.get('input').setValue(true);
 
     expect(wrapper.emitted('update:modelValue')).toEqual([['2']]);
+    expect(wrapper.emitted('change')).toEqual([['2']]);
   });
 
   it('does not emit when disabled', async () => {
@@ -39,5 +41,45 @@ describe('MdRadio', () => {
     await wrapper.get('input').trigger('change');
 
     expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+  });
+
+  it('serializes and resets with form correctly', async () => {
+    const TestHost = defineComponent({
+      components: { MdRadio },
+      data() {
+        return {
+          selected: 'istanbul',
+        };
+      },
+      template: `
+        <form id="city-form">
+          <MdRadio v-model="selected" name="city" value="istanbul" />
+          <MdRadio v-model="selected" name="city" value="ankara" />
+        </form>
+      `,
+    });
+
+    const wrapper = mount(TestHost, {
+      attachTo: document.body,
+    });
+
+    const form = wrapper.get('form').element;
+    const [first, second] = wrapper.findAll('input');
+
+    expect(new FormData(form).get('city')).toBe('istanbul');
+
+    await second.setValue(true);
+    expect(wrapper.vm.selected).toBe('ankara');
+    expect(new FormData(form).get('city')).toBe('ankara');
+
+    form.reset();
+    await nextTick();
+
+    expect(wrapper.vm.selected).toBe('istanbul');
+    expect(first.element.checked).toBe(true);
+    expect(second.element.checked).toBe(false);
+    expect(new FormData(form).get('city')).toBe('istanbul');
+
+    wrapper.unmount();
   });
 });

--- a/tests/unit/components/switch/MdSwitch.spec.js
+++ b/tests/unit/components/switch/MdSwitch.spec.js
@@ -1,0 +1,88 @@
+import { nextTick } from 'vue';
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import MdSwitch from '@/components/switch/MdSwitch.vue';
+
+describe('MdSwitch', () => {
+  it('emits input/change and update:modelValue when toggled', async () => {
+    const wrapper = mount(MdSwitch, {
+      props: {
+        modelValue: false,
+      },
+    });
+
+    await wrapper.get('input').setValue(true);
+
+    expect(wrapper.emitted('input')).toEqual([[true]]);
+    expect(wrapper.emitted('change')).toEqual([[true]]);
+    expect(wrapper.emitted('update:modelValue')).toEqual([[true]]);
+  });
+
+  it('serializes with form data when checked', async () => {
+    const form = document.createElement('form');
+    form.id = 'switch-form';
+    document.body.appendChild(form);
+
+    const wrapper = mount(MdSwitch, {
+      attachTo: document.body,
+      props: {
+        checked: true,
+        form: 'switch-form',
+        name: 'alerts',
+        value: 'enabled',
+      },
+    });
+
+    await nextTick();
+
+    expect(new FormData(form).get('alerts')).toBe('enabled');
+
+    wrapper.unmount();
+    form.remove();
+  });
+
+  it('restores initial state on form reset', async () => {
+    const form = document.createElement('form');
+    form.id = 'switch-reset-form';
+    document.body.appendChild(form);
+
+    const wrapper = mount(MdSwitch, {
+      attachTo: document.body,
+      props: {
+        checked: true,
+        form: 'switch-reset-form',
+        name: 'push',
+      },
+    });
+
+    const input = wrapper.get('input');
+
+    await input.setValue(false);
+    expect(input.element.checked).toBe(false);
+
+    form.reset();
+    await nextTick();
+
+    expect(input.element.checked).toBe(true);
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([true]);
+
+    wrapper.unmount();
+    form.remove();
+  });
+
+  it('does not update when readonly', async () => {
+    const wrapper = mount(MdSwitch, {
+      props: {
+        modelValue: true,
+        readonly: true,
+      },
+    });
+
+    const input = wrapper.get('input');
+    input.element.checked = false;
+    await input.trigger('change');
+
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+    expect(input.element.checked).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- complete form-associated parity for MdCheckbox, MdRadio, and MdSwitch
- add native form props support: name, value, form, required, checked/modelValue
- implement reset behavior with initial-state restore and exposed validity/focus APIs
- align checkbox state-layer/focus behavior with Material sizing (40px state-layer, 48px touch target)
- improve ripple focus handling with focusin/focusout and focus state-layer styling

## Tests
- npm test
- 4 test files, 15 tests passed
