### PR TITLE
feat: slider range/ticks/labeled parity (W2-06)

### DIFF
--- a/src/components/slider/MdSlider.vue
+++ b/src/components/slider/MdSlider.vue
@@ -1,238 +1,762 @@
 <template>
-  <div class="md-slider" :style="{ '--sliderValue': `${getPercent(sliderValue, min, max)}%` }">
-    <div class="md-slider__label-container">
-      <div class="md-slider__label">
-        <span>{{ sliderValue }}</span>
+  <div
+    ref="sliderEl"
+    class="md-slider"
+    :class="{
+      'md-slider--disabled': disabled,
+      'md-slider--labeled': labeled,
+      'md-slider--range': range,
+    }"
+    :style="sliderStyle"
+    @mouseenter="hovered = true"
+    @mouseleave="hovered = false"
+    @pointerdown="onPointerDown"
+    @pointermove="onPointerMove"
+  >
+    <div v-if="labeled" class="md-slider__label-container">
+      <div
+        v-if="range"
+        class="md-slider__label md-slider__label--start"
+        :class="{ 'md-slider__label--visible': showStartLabel }"
+        :style="{ left: `${startPercent}%` }"
+      >
+        <span>{{ startLabel }}</span>
+      </div>
+      <div class="md-slider__label md-slider__label--end" :class="{ 'md-slider__label--visible': showEndLabel }" :style="{ left: `${endPercent}%` }">
+        <span>{{ endLabel }}</span>
       </div>
     </div>
-    <div class="md-slider__tick-container">
-      <div v-for="(tick, index) in getMetrics.tickCount" :class="{ 'md-slider__tick--left': index < (sliderValue - min) / step }" class="md-slider__tick"></div>
+
+    <div class="md-slider__track-container">
+      <div class="md-slider__track md-slider__track--inactive"></div>
+      <div class="md-slider__track md-slider__track--active" :style="activeTrackStyle"></div>
+      <div v-if="hasTicks && tickValues.length > 0" class="md-slider__tick-container">
+        <div
+          v-for="tick in tickValues"
+          :key="`tick-${tick}`"
+          class="md-slider__tick"
+          :class="{ 'md-slider__tick--active': isTickActive(tick) }"
+          :style="{ left: `${toPercent(tick)}%` }"
+        ></div>
+      </div>
     </div>
-    <input :value="sliderValue" @input="onInput" type="range" :min="min" :max="max" :step="step" class="slider" />
+
+    <input
+      v-if="range"
+      ref="startInputEl"
+      class="md-slider__input md-slider__input--start"
+      :class="{ 'md-slider__input--on-top': startOnTop }"
+      type="range"
+      :value="startValue"
+      :min="normalizedMin"
+      :max="normalizedMax"
+      :step="normalizedStep"
+      :disabled="disabled"
+      :name="startInputName"
+      :form="form || undefined"
+      :required="required"
+      :aria-label="ariaLabelStart || `${ariaLabel || 'slider'} start`"
+      @input="onStartInput"
+      @change="onStartChange"
+      @focus="onStartFocus"
+      @blur="onStartBlur"
+    />
+
+    <input
+      ref="endInputEl"
+      class="md-slider__input md-slider__input--end"
+      :class="{ 'md-slider__input--on-top': !startOnTop }"
+      type="range"
+      :value="endValue"
+      :min="normalizedMin"
+      :max="normalizedMax"
+      :step="normalizedStep"
+      :disabled="disabled"
+      :name="endInputName"
+      :form="form || undefined"
+      :required="required"
+      :aria-label="ariaLabelEnd || ariaLabel || 'slider'"
+      @input="onEndInput"
+      @change="onEndChange"
+      @focus="onEndFocus"
+      @blur="onEndBlur"
+    />
   </div>
 </template>
 
 <script setup>
-import { ref, computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 
-const { min, max, step, modelValue, withTickMarks } = defineProps({
-  min: {
-    type: Number,
-    default: 0,
-  },
-  max: {
-    type: Number,
-    default: 100,
-  },
-  step: {
-    type: Number,
-    default: 1,
-  },
-  modelValue: {
-    type: Number,
-    default: 50,
-  },
-  withTickMarks: {
-    type: Boolean,
-    default: true,
-  },
+const props = defineProps({
+  ariaLabel: { type: String, default: '' },
+  ariaLabelEnd: { type: String, default: '' },
+  ariaLabelStart: { type: String, default: '' },
+  disabled: { type: Boolean, default: false },
+  form: { type: String, default: '' },
+  labeled: { type: Boolean, default: false },
+  max: { type: Number, default: 100 },
+  min: { type: Number, default: 0 },
+  modelValue: { type: [Number, Object, Array], default: undefined },
+  name: { type: String, default: '' },
+  nameEnd: { type: String, default: '' },
+  nameStart: { type: String, default: '' },
+  range: { type: Boolean, default: false },
+  required: { type: Boolean, default: false },
+  step: { type: Number, default: 1 },
+  ticks: { type: Boolean, default: false },
+  value: { type: Number, default: undefined },
+  valueEnd: { type: Number, default: undefined },
+  valueLabel: { type: String, default: '' },
+  valueLabelEnd: { type: String, default: '' },
+  valueLabelStart: { type: String, default: '' },
+  valueStart: { type: Number, default: undefined },
+  withTickMarks: { type: Boolean, default: false },
 });
 
-const emit = defineEmits(['update:modelValue']);
+const emit = defineEmits(['update:modelValue', 'update:valueStart', 'update:valueEnd', 'input', 'change', 'focus', 'blur']);
 
-const sliderValue = ref(modelValue);
+const startInputEl = ref(null);
+const endInputEl = ref(null);
+const sliderEl = ref(null);
+const startValue = ref(0);
+const endValue = ref(0);
+const hovered = ref(false);
+const startFocused = ref(false);
+const endFocused = ref(false);
+const activeThumb = ref('');
 
-const getPercent = (value, min, max) => {
+const normalizedStep = computed(() => (Number.isFinite(props.step) && props.step > 0 ? props.step : 1));
+
+const normalizedBounds = computed(() => {
+  const min = Number.isFinite(props.min) ? props.min : 0;
+  const max = Number.isFinite(props.max) ? props.max : 100;
+  return min <= max ? { min, max } : { min: max, max: min };
+});
+
+const normalizedMin = computed(() => normalizedBounds.value.min);
+const normalizedMax = computed(() => normalizedBounds.value.max);
+
+const hasTicks = computed(() => props.ticks || props.withTickMarks);
+
+const getStepPrecision = (stepValue) => {
+  const stepAsString = String(stepValue);
+
+  if (stepAsString.includes('e-')) {
+    return Number(stepAsString.split('e-')[1] || 0);
+  }
+
+  const decimal = stepAsString.split('.')[1];
+  return decimal ? decimal.length : 0;
+};
+
+const stepPrecision = computed(() => getStepPrecision(normalizedStep.value));
+
+const normalizeNumber = (value, fallback) => {
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) ? numericValue : fallback;
+};
+
+const clampToBounds = (value) => {
+  const { min, max } = normalizedBounds.value;
+  return Math.min(max, Math.max(min, value));
+};
+
+const alignToStep = (value) => {
+  const { min } = normalizedBounds.value;
+  const stepValue = normalizedStep.value;
+  const steppedValue = min + Math.round((value - min) / stepValue) * stepValue;
+  return Number(steppedValue.toFixed(stepPrecision.value));
+};
+
+const normalizeSliderValue = (value, fallback) => {
+  const numericValue = normalizeNumber(value, fallback);
+  return clampToBounds(alignToStep(numericValue));
+};
+
+const initializeSingle = () => {
+  const { min } = normalizedBounds.value;
+  const sourceValue = props.modelValue ?? props.value ?? min;
+  startValue.value = min;
+  endValue.value = normalizeSliderValue(sourceValue, min);
+};
+
+const initializeRange = () => {
+  const { min, max } = normalizedBounds.value;
+  let nextStart = normalizeSliderValue(props.valueStart ?? min, min);
+  let nextEnd = normalizeSliderValue(props.valueEnd ?? max, max);
+
+  if (nextStart > nextEnd) {
+    [nextStart, nextEnd] = [nextEnd, nextStart];
+  }
+
+  startValue.value = nextStart;
+  endValue.value = nextEnd;
+};
+
+const syncFromProps = () => {
+  if (props.range) {
+    initializeRange();
+    return;
+  }
+
+  initializeSingle();
+};
+
+watch(() => [props.range, props.min, props.max, props.step], syncFromProps, { immediate: true });
+
+watch(
+  () => props.modelValue,
+  (newValue) => {
+    if (props.range || newValue === undefined || typeof newValue === 'object') {
+      return;
+    }
+
+    endValue.value = normalizeSliderValue(newValue, endValue.value);
+  },
+);
+
+watch(
+  () => props.value,
+  (newValue) => {
+    if (props.range || props.modelValue !== undefined || newValue === undefined) {
+      return;
+    }
+
+    endValue.value = normalizeSliderValue(newValue, endValue.value);
+  },
+);
+
+watch(
+  () => [props.valueStart, props.valueEnd],
+  ([nextStart, nextEnd]) => {
+    if (!props.range) {
+      return;
+    }
+
+    let normalizedStart = nextStart === undefined ? startValue.value : normalizeSliderValue(nextStart, startValue.value);
+    let normalizedEnd = nextEnd === undefined ? endValue.value : normalizeSliderValue(nextEnd, endValue.value);
+
+    if (normalizedStart > normalizedEnd) {
+      [normalizedStart, normalizedEnd] = [normalizedEnd, normalizedStart];
+    }
+
+    startValue.value = normalizedStart;
+    endValue.value = normalizedEnd;
+  },
+);
+
+const toPercent = (value) => {
+  const { min, max } = normalizedBounds.value;
+  if (max === min) {
+    return 0;
+  }
   return ((value - min) / (max - min)) * 100;
 };
 
-const getMetrics = computed(() => {
-  const _step = Math.max(step, 1);
-  const _range = Math.max(max - min, _step);
+const startPercent = computed(() => (props.range ? toPercent(startValue.value) : 0));
+const endPercent = computed(() => toPercent(endValue.value));
 
-  return {
-    step: _step,
-    range: _range,
-    tickCount: _range / _step + 1,
-  };
+const startOnTop = computed(() => {
+  if (!props.range) {
+    return false;
+  }
+
+  if (activeThumb.value === 'start') {
+    return true;
+  }
+
+  if (activeThumb.value === 'end') {
+    return false;
+  }
+
+  return startValue.value >= endValue.value;
 });
 
-const onInput = ({ target }) => {
-  sliderValue.value = parseFloat(target.value);
+const activeTrackStyle = computed(() => ({
+  left: `${Math.min(startPercent.value, endPercent.value)}%`,
+  width: `${Math.max(endPercent.value - startPercent.value, 0)}%`,
+}));
+
+const sliderStyle = computed(() => ({
+  '--slider-start-percent': `${startPercent.value}%`,
+  '--slider-end-percent': `${endPercent.value}%`,
+  '--md-slider-split-percent': `${(startPercent.value + endPercent.value) / 2}%`,
+}));
+
+const tickValues = computed(() => {
+  if (!hasTicks.value) {
+    return [];
+  }
+
+  const { min, max } = normalizedBounds.value;
+  const stepValue = normalizedStep.value;
+  const count = Math.floor((max - min) / stepValue) + 1;
+
+  // Guardrail to prevent rendering hundreds/thousands of DOM nodes.
+  if (count < 2 || count > 201) {
+    return [];
+  }
+
+  return Array.from({ length: count }, (_, index) => Number((min + index * stepValue).toFixed(stepPrecision.value)));
+});
+
+const isTickActive = (value) => {
+  if (props.range) {
+    return value >= startValue.value && value <= endValue.value;
+  }
+  return value <= endValue.value;
 };
+
+const startLabel = computed(() => props.valueLabelStart || startValue.value);
+const endLabel = computed(() => {
+  if (props.range) {
+    return props.valueLabelEnd || endValue.value;
+  }
+
+  return props.valueLabel || endValue.value;
+});
+
+const showStartLabel = computed(() => props.range && props.labeled && (hovered.value || startFocused.value));
+const showEndLabel = computed(() => props.labeled && (hovered.value || endFocused.value));
+
+const startInputName = computed(() => {
+  if (!props.range) {
+    return undefined;
+  }
+
+  return props.nameStart || props.name || undefined;
+});
+
+const endInputName = computed(() => {
+  if (!props.range) {
+    return props.name || undefined;
+  }
+
+  return props.nameEnd || props.nameStart || props.name || undefined;
+});
+
+const buildRangePayload = (thumb) => ({
+  activeThumb: thumb,
+  valueEnd: endValue.value,
+  valueStart: startValue.value,
+});
+
+const emitSingle = (eventName) => {
+  emit('update:modelValue', endValue.value);
+  emit(eventName, endValue.value);
+};
+
+const emitRange = (eventName, thumb) => {
+  emit('update:valueStart', startValue.value);
+  emit('update:valueEnd', endValue.value);
+  emit('update:modelValue', {
+    valueEnd: endValue.value,
+    valueStart: startValue.value,
+  });
+  emit(eventName, buildRangePayload(thumb));
+};
+
+const onStartInput = (event) => {
+  if (props.disabled) {
+    return;
+  }
+
+  activeThumb.value = 'start';
+  const rawValue = normalizeSliderValue(event.target.value, startValue.value);
+  startValue.value = Math.min(rawValue, endValue.value);
+  event.target.value = String(startValue.value);
+  emitRange('input', 'start');
+};
+
+const onStartChange = (event) => {
+  if (props.disabled) {
+    return;
+  }
+
+  activeThumb.value = 'start';
+  const rawValue = normalizeSliderValue(event.target.value, startValue.value);
+  startValue.value = Math.min(rawValue, endValue.value);
+  event.target.value = String(startValue.value);
+  emitRange('change', 'start');
+};
+
+const onEndInput = (event) => {
+  if (props.disabled) {
+    return;
+  }
+
+  activeThumb.value = 'end';
+  const rawValue = normalizeSliderValue(event.target.value, endValue.value);
+
+  if (props.range) {
+    endValue.value = Math.max(rawValue, startValue.value);
+    event.target.value = String(endValue.value);
+    emitRange('input', 'end');
+    return;
+  }
+
+  endValue.value = rawValue;
+  event.target.value = String(endValue.value);
+  emitSingle('input');
+};
+
+const onEndChange = (event) => {
+  if (props.disabled) {
+    return;
+  }
+
+  activeThumb.value = 'end';
+  const rawValue = normalizeSliderValue(event.target.value, endValue.value);
+
+  if (props.range) {
+    endValue.value = Math.max(rawValue, startValue.value);
+    event.target.value = String(endValue.value);
+    emitRange('change', 'end');
+    return;
+  }
+
+  endValue.value = rawValue;
+  event.target.value = String(endValue.value);
+  emitSingle('change');
+};
+
+const onStartFocus = (event) => {
+  startFocused.value = true;
+  activeThumb.value = 'start';
+  emit('focus', event);
+};
+
+const onStartBlur = (event) => {
+  startFocused.value = false;
+  if (!endFocused.value) {
+    activeThumb.value = '';
+  }
+  emit('blur', event);
+};
+
+const onEndFocus = (event) => {
+  endFocused.value = true;
+  activeThumb.value = 'end';
+  emit('focus', event);
+};
+
+const onEndBlur = (event) => {
+  endFocused.value = false;
+  if (!startFocused.value) {
+    activeThumb.value = '';
+  }
+  emit('blur', event);
+};
+
+const getPointerPercent = (event) => {
+  const rect = sliderEl.value?.getBoundingClientRect();
+  if (!rect || rect.width <= 0) {
+    return endPercent.value;
+  }
+
+  const clampedX = Math.min(rect.right, Math.max(rect.left, event.clientX));
+  return ((clampedX - rect.left) / rect.width) * 100;
+};
+
+const updateActiveThumbFromPointer = (event) => {
+  if (!props.range || props.disabled) {
+    return;
+  }
+
+  const pointerPercent = getPointerPercent(event);
+  const distanceToStart = Math.abs(pointerPercent - startPercent.value);
+  const distanceToEnd = Math.abs(pointerPercent - endPercent.value);
+  activeThumb.value = distanceToStart <= distanceToEnd ? 'start' : 'end';
+};
+
+const onPointerDown = (event) => {
+  updateActiveThumbFromPointer(event);
+};
+
+const onPointerMove = (event) => {
+  if (event.buttons !== 0) {
+    return;
+  }
+
+  updateActiveThumbFromPointer(event);
+};
+
+const focus = () => endInputEl.value?.focus();
+const focusStart = () => startInputEl.value?.focus();
+const focusEnd = () => endInputEl.value?.focus();
+const blur = () => {
+  startInputEl.value?.blur();
+  endInputEl.value?.blur();
+};
+const checkValidity = () => {
+  if (!props.range) {
+    return endInputEl.value?.checkValidity();
+  }
+
+  const isStartValid = startInputEl.value?.checkValidity() ?? true;
+  const isEndValid = endInputEl.value?.checkValidity() ?? true;
+  return isStartValid && isEndValid;
+};
+const reportValidity = () => {
+  if (!props.range) {
+    return endInputEl.value?.reportValidity();
+  }
+
+  const isStartValid = startInputEl.value?.reportValidity() ?? true;
+  const isEndValid = endInputEl.value?.reportValidity() ?? true;
+  return isStartValid && isEndValid;
+};
+
+defineExpose({
+  blur,
+  checkValidity,
+  focus,
+  focusEnd,
+  focusStart,
+  reportValidity,
+});
 </script>
 
 <style lang="scss">
 @use 'sass:map';
 @use '../../styles/tokens';
-@use '../ripple/ripple';
 
 $theme: tokens.md-comp-slider-values();
 
 .md-slider {
-  --trackHeight: #{map.get($theme, active-track-height)};
-  --thumbRadius: #{map.get($theme, handle-width)};
+  --md-slider-track-height: #{map.get($theme, active-track-height)};
+  --md-slider-thumb-size: #{map.get($theme, handle-width)};
+  --md-slider-state-layer-size: #{map.get($theme, state-layer-size)};
+  --md-slider-label-height: #{map.get($theme, label-container-height)};
+  --md-slider-hover-overlay-color: #{map.get($theme, hover-state-layer-color)}1f;
+  --md-slider-focus-overlay-color: #{map.get($theme, focus-state-layer-color)}33;
+  --md-slider-pressed-overlay-color: #{map.get($theme, pressed-state-layer-color)}4d;
+  --md-slider-top-offset: 0px;
+  box-sizing: border-box;
   position: relative;
-  height: map.get($theme, handle-width);
+  inline-size: 100%;
+  min-block-size: var(--md-slider-state-layer-size);
+  user-select: none;
 
-  &__tick-container {
-    position: absolute;
-    left: 0;
-    right: 0;
-    height: var(--trackHeight);
-    z-index: 1;
-    top: calc(50% - var(--trackHeight) / 2);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-  &__tick {
-    background-color: map.get($theme, with-tick-marks-inactive-container-color);
-    opacity: map.get($theme, with-tick-marks-inactive-container-opacity);
-    width: map.get($theme, with-tick-marks-container-size);
-    height: map.get($theme, with-tick-marks-container-size);
-    border-radius: map.get($theme, with-tick-marks-container-shape);
-    outline: solid map.get($theme, with-overlap-handle-outline-width) map.get($theme, with-tick-marks-inactive-container-color);
-  }
-  &__tick--left {
-    background-color: map.get($theme, with-tick-marks-active-container-color);
-    opacity: map.get($theme, with-tick-marks-active-container-opacity);
+  &--labeled {
+    --md-slider-top-offset: calc(var(--md-slider-label-height) + 8px);
+    min-block-size: calc(var(--md-slider-state-layer-size) + var(--md-slider-top-offset));
   }
 
   &__label-container {
     position: absolute;
-    left: calc(#{map.get($theme, handle-height)} / 2);
-    right: calc(#{map.get($theme, handle-height)} / 2);
+    inset-inline: calc(var(--md-slider-thumb-size) / 2);
+    inset-block-start: 0;
+    block-size: var(--md-slider-label-height);
+    pointer-events: none;
+    z-index: 5;
   }
 
   &__label {
-    left: var(--sliderValue, 100%);
-    margin-left: calc(#{map.get($theme, label-container-height)}/ 2 * -1);
     position: absolute;
-    box-sizing: border-box;
+    inset-block-start: 0;
     display: grid;
-    padding: 4px;
     place-items: center;
+    min-inline-size: var(--md-slider-label-height);
+    min-block-size: var(--md-slider-label-height);
+    padding: 4px;
     border-radius: 999px;
+    background: map.get($theme, label-container-color);
     color: map.get($theme, label-label-text-color);
     font: map.get($theme, label-label-text-type);
-    top: -32px;
-    min-inline-size: map.get($theme, label-container-height);
-    min-block-size: map.get($theme, label-container-height);
-    background: map.get($theme, label-container-color);
-    transition-property: transform;
-    transition-duration: 280ms;
-    transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
+    transform: translateX(-50%) scale(0);
     transform-origin: center bottom;
-    transform: scale(0);
-
-    &:before {
-      --triangleSize: calc(#{map.get($theme, label-container-height)} / 2);
-      --triangleOffset: calc(#{map.get($theme, label-container-height)} / -10);
-      inline-size: var(--triangleSize);
-      block-size: var(--triangleSize);
-      bottom: var(--triangleOffset);
-      transform: rotate(45deg);
-    }
-
-    &::before,
-    &::after {
-      position: absolute;
-      display: block;
-      content: '';
-      background: inherit;
-    }
-
-    span {
-      z-index: 1;
-    }
-  }
-
-  &:hover .md-slider__label {
-    transform: scale(1);
-  }
-
-  input[type='range'] {
-    position: relative;
-    appearance: none;
-    border-radius: map.get($theme, active-track-shape);
-    /* z-index: 0; */
-    margin: 0;
-    padding: 0;
-    cursor: pointer;
-    width: 100%;
-    height: inherit;
+    transition: transform 180ms cubic-bezier(0.2, 0, 0, 1);
 
     &::before {
       content: '';
       position: absolute;
-      width: var(--sliderValue, 100%);
-      height: var(--trackHeight);
-      top: calc(50% - var(--trackHeight) / 2);
+      inset-block-end: calc(var(--md-slider-label-height) / -10);
+      inline-size: calc(var(--md-slider-label-height) / 2);
+      block-size: calc(var(--md-slider-label-height) / 2);
+      transform: rotate(45deg);
+      background: inherit;
+    }
+
+    span {
+      position: relative;
+      z-index: 1;
+    }
+
+    &--visible {
+      transform: translateX(-50%) scale(1);
+    }
+  }
+
+  &__track-container {
+    position: absolute;
+    inset-inline: calc(var(--md-slider-thumb-size) / 2);
+    inset-block-start: calc(var(--md-slider-top-offset) + (var(--md-slider-state-layer-size) / 2));
+    block-size: var(--md-slider-track-height);
+    transform: translateY(-50%);
+    z-index: 1;
+  }
+
+  &__track {
+    position: absolute;
+    inset-block: 0;
+    border-radius: map.get($theme, inactive-track-shape);
+
+    &--inactive {
+      inset-inline: 0;
+      background: map.get($theme, inactive-track-color);
+    }
+
+    &--active {
       background: map.get($theme, active-track-color);
-      pointer-events: none;
-      border-radius: map.get($theme, inactive-track-shape);
+    }
+  }
+
+  &__tick-container {
+    position: absolute;
+    inset-inline: 0;
+    inset-block-start: 50%;
+    block-size: map.get($theme, with-tick-marks-container-size);
+    transform: translateY(-50%);
+    z-index: 2;
+    pointer-events: none;
+  }
+
+  &__tick {
+    position: absolute;
+    inline-size: map.get($theme, with-tick-marks-container-size);
+    block-size: map.get($theme, with-tick-marks-container-size);
+    border-radius: map.get($theme, with-tick-marks-container-shape);
+    background-color: map.get($theme, with-tick-marks-inactive-container-color);
+    opacity: map.get($theme, with-tick-marks-inactive-container-opacity);
+    transform: translate(-50%, -50%);
+    outline: solid map.get($theme, with-overlap-handle-outline-width) map.get($theme, with-tick-marks-inactive-container-color);
+
+    &--active {
+      background-color: map.get($theme, with-tick-marks-active-container-color);
+      opacity: map.get($theme, with-tick-marks-active-container-opacity);
+      outline-color: map.get($theme, with-tick-marks-active-container-color);
+    }
+  }
+
+  &__input {
+    position: absolute;
+    inset-inline: 0;
+    inset-block-start: var(--md-slider-top-offset);
+    inline-size: 100%;
+    block-size: var(--md-slider-state-layer-size);
+    margin: 0;
+    appearance: none;
+    background: transparent;
+    outline: none;
+    cursor: pointer;
+    z-index: 3;
+
+    &--on-top {
+      z-index: 4;
     }
 
     &::-webkit-slider-runnable-track {
       appearance: none;
-      background: map.get($theme, inactive-track-color);
-      height: var(--trackHeight);
-      border-radius: map.get($theme, inactive-track-shape);
+      block-size: var(--md-slider-track-height);
+      background: transparent;
     }
 
     &::-moz-range-track {
       appearance: none;
-      background: map.get($theme, inactive-track-color);
-      height: var(--trackHeight);
-      border-radius: map.get($theme, inactive-track-shape);
+      block-size: var(--md-slider-track-height);
+      background: transparent;
     }
 
     &::-moz-range-progress {
       appearance: none;
-      background: map.get($theme, active-track-color);
-      height: var(--trackHeight);
-      border-radius: map.get($theme, inactive-track-shape);
-    }
-
-    &::-moz-range-thumb {
-      position: relative;
-      width: var(--thumbRadius);
-      height: var(--thumbRadius);
-      margin-top: calc((var(--trackHeight) - var(--thumbRadius)) / 2);
-      background: map.get($theme, handle-color);
-      border-radius: map.get($theme, handle-shape);
-      pointer-events: all;
-      appearance: none;
-      z-index: 2;
-      transition: ease box-shadow 100ms;
-    }
-
-    &::-moz-range-thumb:hover {
-      box-shadow: 0 0 0 calc(#{map.get($theme, state-layer-size)}/ 4) #6750a415;
-    }
-    &::-moz-range-thumb:active {
-      box-shadow: 0 0 0 calc(#{map.get($theme, state-layer-size)}/ 4) #6750a455;
+      block-size: var(--md-slider-track-height);
+      background: transparent;
     }
 
     &::-webkit-slider-thumb {
-      position: relative;
-      width: var(--thumbRadius);
-      height: var(--thumbRadius);
-      margin-top: calc((var(--trackHeight) - var(--thumbRadius)) / 2);
-      background: map.get($theme, handle-color);
-      border-radius: map.get($theme, handle-shape);
-      pointer-events: all;
       appearance: none;
-      z-index: 2;
-      transition: ease box-shadow 100ms;
+      inline-size: var(--md-slider-thumb-size);
+      block-size: var(--md-slider-thumb-size);
+      margin-top: calc((var(--md-slider-track-height) - var(--md-slider-thumb-size)) / 2);
+      border-radius: map.get($theme, handle-shape);
+      background-color: map.get($theme, handle-color);
+      border: 0;
+      transition: box-shadow 120ms ease;
     }
 
-    &::-webkit-slider-thumb:hover {
-      box-shadow: 0 0 0 calc(#{map.get($theme, state-layer-size)}/ 4) #6750a415;
+    &::-moz-range-thumb {
+      appearance: none;
+      inline-size: var(--md-slider-thumb-size);
+      block-size: var(--md-slider-thumb-size);
+      border-radius: map.get($theme, handle-shape);
+      background-color: map.get($theme, handle-color);
+      border: 0;
+      transition: box-shadow 120ms ease;
     }
-    &::-webkit-slider-thumb:active {
-      box-shadow: 0 0 0 calc(#{map.get($theme, state-layer-size)}/ 4) #6750a455;
+
+    &:hover::-webkit-slider-thumb,
+    &:hover::-moz-range-thumb {
+      box-shadow: 0 0 0 calc(var(--md-slider-state-layer-size) / 4) var(--md-slider-hover-overlay-color);
+    }
+
+    &:focus-visible::-webkit-slider-thumb,
+    &:focus-visible::-moz-range-thumb {
+      box-shadow: 0 0 0 calc(var(--md-slider-state-layer-size) / 4) var(--md-slider-focus-overlay-color);
+    }
+
+    &:active::-webkit-slider-thumb,
+    &:active::-moz-range-thumb {
+      box-shadow: 0 0 0 calc(var(--md-slider-state-layer-size) / 4) var(--md-slider-pressed-overlay-color);
+    }
+  }
+
+  &--range {
+    .md-slider__input--start {
+      clip-path: polygon(
+        0 0,
+        calc(var(--md-slider-split-percent) + (var(--md-slider-thumb-size) / 2)) 0,
+        calc(var(--md-slider-split-percent) + (var(--md-slider-thumb-size) / 2)) 100%,
+        0 100%
+      );
+    }
+
+    .md-slider__input--end {
+      clip-path: polygon(
+        calc(var(--md-slider-split-percent) - (var(--md-slider-thumb-size) / 2)) 0,
+        100% 0,
+        100% 100%,
+        calc(var(--md-slider-split-percent) - (var(--md-slider-thumb-size) / 2)) 100%
+      );
+    }
+  }
+
+  &--disabled {
+    pointer-events: none;
+
+    .md-slider__track--inactive {
+      background: map.get($theme, disabled-inactive-track-color);
+      opacity: map.get($theme, disabled-inactive-track-opacity);
+    }
+
+    .md-slider__track--active {
+      background: map.get($theme, disabled-active-track-color);
+      opacity: map.get($theme, disabled-active-track-opacity);
+    }
+
+    .md-slider__tick {
+      background-color: map.get($theme, with-tick-marks-disabled-container-color);
+      opacity: map.get($theme, with-tick-marks-disabled-container-opacity);
+      outline-color: map.get($theme, with-tick-marks-disabled-container-color);
+    }
+
+    .md-slider__input {
+      &::-webkit-slider-thumb,
+      &::-moz-range-thumb {
+        background-color: map.get($theme, disabled-handle-color);
+        opacity: map.get($theme, disabled-handle-opacity);
+        box-shadow: none;
+      }
     }
   }
 }

--- a/stories/components/slider/MdSlider.stories.js
+++ b/stories/components/slider/MdSlider.stories.js
@@ -1,0 +1,131 @@
+import { ref, watch } from 'vue';
+import MdSlider from '../../../src/components/slider/MdSlider.vue';
+
+export default {
+  title: 'Components/Slider',
+  component: MdSlider,
+  argTypes: {
+    disabled: { control: 'boolean' },
+    labeled: { control: 'boolean' },
+    max: { control: 'number' },
+    min: { control: 'number' },
+    step: { control: 'number' },
+    ticks: { control: 'boolean' },
+  },
+};
+
+const SingleTemplate = (args) => ({
+  components: { MdSlider },
+  setup() {
+    const singleValue = ref(args.modelValue ?? 50);
+
+    watch(
+      () => args.modelValue,
+      (nextValue) => {
+        if (nextValue === undefined) {
+          return;
+        }
+        singleValue.value = nextValue;
+      },
+    );
+
+    return { args, singleValue };
+  },
+  template: `
+    <div style="max-width: 520px; padding: 20px;">
+      <MdSlider v-bind="args" :range="false" v-model="singleValue" />
+      <p style="margin-top: 12px; font-family: sans-serif;">Value: {{ singleValue }}</p>
+    </div>
+  `,
+});
+
+const RangeTemplate = (args) => ({
+  components: { MdSlider },
+  setup() {
+    const valueStart = ref(args.valueStart ?? 30);
+    const valueEnd = ref(args.valueEnd ?? 70);
+
+    watch(
+      () => args.valueStart,
+      (nextValue) => {
+        if (nextValue === undefined) {
+          return;
+        }
+        valueStart.value = nextValue;
+      },
+    );
+
+    watch(
+      () => args.valueEnd,
+      (nextValue) => {
+        if (nextValue === undefined) {
+          return;
+        }
+        valueEnd.value = nextValue;
+      },
+    );
+
+    return { args, valueEnd, valueStart };
+  },
+  template: `
+    <div style="max-width: 520px; padding: 20px;">
+      <MdSlider
+        v-bind="args"
+        range
+        :value-start="valueStart"
+        :value-end="valueEnd"
+        @update:valueStart="valueStart = $event"
+        @update:valueEnd="valueEnd = $event"
+      />
+      <p style="margin-top: 12px; font-family: sans-serif;">
+        Range: {{ valueStart }} - {{ valueEnd }}
+      </p>
+    </div>
+  `,
+});
+
+export const Single = SingleTemplate.bind({});
+Single.args = {
+  min: 0,
+  max: 100,
+  step: 1,
+  modelValue: 50,
+  ticks: false,
+  labeled: false,
+  disabled: false,
+};
+
+export const LabeledTicks = SingleTemplate.bind({});
+LabeledTicks.args = {
+  min: 0,
+  max: 100,
+  step: 10,
+  modelValue: 40,
+  ticks: true,
+  labeled: true,
+  disabled: false,
+};
+
+export const Range = RangeTemplate.bind({});
+Range.args = {
+  min: 0,
+  max: 100,
+  step: 1,
+  valueStart: 25,
+  valueEnd: 75,
+  ticks: false,
+  labeled: false,
+  disabled: false,
+};
+
+export const RangeLabeledTicks = RangeTemplate.bind({});
+RangeLabeledTicks.args = {
+  min: 0,
+  max: 100,
+  step: 10,
+  valueStart: 30,
+  valueEnd: 70,
+  ticks: true,
+  labeled: true,
+  disabled: false,
+};

--- a/tests/unit/components/slider/MdSlider.spec.js
+++ b/tests/unit/components/slider/MdSlider.spec.js
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import MdSlider from '@/components/slider/MdSlider.vue';
+
+describe('MdSlider', () => {
+  it('emits single slider updates on input/change', async () => {
+    const wrapper = mount(MdSlider, {
+      props: {
+        min: 0,
+        max: 100,
+        step: 1,
+        modelValue: 50,
+      },
+    });
+
+    const input = wrapper.get('.md-slider__input--end');
+    input.element.value = '70';
+    await input.trigger('input');
+    await input.trigger('change');
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[70], [70]]);
+    expect(wrapper.emitted('input')).toEqual([[70]]);
+    expect(wrapper.emitted('change')).toEqual([[70]]);
+  });
+
+  it('keeps range values ordered and emits start/end updates', async () => {
+    const wrapper = mount(MdSlider, {
+      props: {
+        range: true,
+        min: 0,
+        max: 100,
+        step: 1,
+        valueStart: 20,
+        valueEnd: 80,
+      },
+    });
+
+    const startInput = wrapper.get('.md-slider__input--start');
+    startInput.element.value = '95';
+    await startInput.trigger('input');
+
+    expect(wrapper.emitted('update:valueStart')?.[0]).toEqual([80]);
+    expect(wrapper.emitted('input')?.[0]).toEqual([
+      {
+        activeThumb: 'start',
+        valueEnd: 80,
+        valueStart: 80,
+      },
+    ]);
+  });
+
+  it('renders tick marks when ticks is enabled', () => {
+    const wrapper = mount(MdSlider, {
+      props: {
+        min: 0,
+        max: 100,
+        step: 10,
+        ticks: true,
+      },
+    });
+
+    const ticks = wrapper.findAll('.md-slider__tick');
+    expect(ticks.length).toBe(11);
+  });
+
+  it('shows labels when labeled slider is hovered', async () => {
+    const wrapper = mount(MdSlider, {
+      props: {
+        labeled: true,
+        modelValue: 40,
+      },
+    });
+
+    await wrapper.trigger('mouseenter');
+
+    expect(wrapper.find('.md-slider__label--end').classes()).toContain('md-slider__label--visible');
+  });
+});


### PR DESCRIPTION
## Summary
- refactor MdSlider to support single and range modes in one component
- add valueStart/valueEnd sync, clamping, and event contract for input/change
- implement ticks and labeled behavior for single and range variants
- fix range thumb targeting so left and right handles are independently draggable
- add Storybook stories for single, labeled+ticks, range, and range+labeled+ticks
- add unit tests for single/range sync, ticks rendering, and labeled visibility

## Tests
- npm test
- 6 test files, 24 tests passed
