### PR TITLE
fix(ci): remove release tag name prefix

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,6 +36,7 @@ jobs:
         uses: GoogleCloudPlatform/release-please-action@v4
         with:
           command: manifest
+          include-component-in-tag: false
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": false,
   "packages": {
     ".": {
-      "release-type": "node",
-      "component": "vue-material-3"
+      "release-type": "node"
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove component from release-please manifest config
- explicitly keep include-component-in-tag: false

## Why
Recent release created vue-material-3-v0.9.0 tag/name format. This restores standard vX.Y.Z tag naming for future releases.