### PR TITLE
Allow manual release PR creation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,11 @@ on:
       - master
   workflow_dispatch:
     inputs:
+      release_as:
+        description: "Open a release PR for this exact version (example: 0.13.1)"
+        required: false
+        default: ''
+        type: string
       simulate_publish_failure:
         description: Simulate npm publish failure (for rollback test)
         required: false
@@ -25,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
 
   release-please-pr:
-    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.reconcile_tag == '' && inputs.simulate_publish_failure == true) }}
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.reconcile_tag == '') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -35,10 +40,10 @@ jobs:
       - id: release
         uses: GoogleCloudPlatform/release-please-action@v4
         with:
-          command: manifest
           include-component-in-tag: false
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          release-as: ${{ inputs.release_as }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Normalize release outputs


### PR DESCRIPTION
## Summary
- allow the release-please workflow to run manually from the Actions UI
- add a release_as input so a specific version PR can be opened on demand
- remove the deprecated command input from release-please-action v4

## Usage
Run the release-please workflow manually and set release_as to the target version, for example 0.13.1.

## Notes
This only opens the release PR. Publishing, npm release, and docs/storybook deployment still happen after the release PR is merged and release-please creates the GitHub release.