### PR TITLE
Add manual release PR workflow

### DIFF
--- a/.github/workflows/manual-release-pr.yml
+++ b/.github/workflows/manual-release-pr.yml
@@ -1,0 +1,70 @@
+name: manual-release-pr
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to prepare (example: 0.13.1)"
+        required: true
+        type: string
+      notes:
+        description: "Release notes to place in CHANGELOG"
+        required: false
+        default: "Manual release."
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Setup Node.js 24.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Validate version
+        run: |
+          if ! echo "${VERSION}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "Invalid version: ${VERSION}"
+            exit 1
+          fi
+        env:
+          VERSION: ${{ inputs.version }}
+
+      - name: Update release files
+        run: |
+          npm version "${VERSION}" --no-git-tag-version
+          node scripts/prepare-manual-release.mjs "${VERSION}" "${NOTES}"
+        env:
+          VERSION: ${{ inputs.version }}
+          NOTES: ${{ inputs.notes }}
+
+      - name: Create release PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: release/manual-v${{ inputs.version }}
+          base: master
+          delete-branch: true
+          commit-message: "chore(master): release ${{ inputs.version }}"
+          title: "chore(master): release ${{ inputs.version }}"
+          body: |
+            Manual release PR for `v${{ inputs.version }}`.
+
+            This updates:
+            - `package.json`
+            - `package-lock.json`
+            - `.release-please-manifest.json`
+            - `CHANGELOG.md`
+
+            After this PR is merged, the existing release workflow will publish the package and deploy docs + Storybook.

--- a/.github/workflows/manual-release-pr.yml
+++ b/.github/workflows/manual-release-pr.yml
@@ -3,10 +3,15 @@ name: manual-release-pr
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: "Version to prepare (example: 0.13.1)"
+      release_type:
+        description: "Version bump type"
         required: true
-        type: string
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
       notes:
         description: "Release notes to place in CHANGELOG"
         required: false
@@ -32,34 +37,33 @@ jobs:
           node-version: 24
           cache: npm
 
-      - name: Validate version
+      - name: Calculate next version
+        id: version
         run: |
-          if ! echo "${VERSION}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
-            echo "Invalid version: ${VERSION}"
-            exit 1
-          fi
+          npm version "${RELEASE_TYPE}" --no-git-tag-version
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
         env:
-          VERSION: ${{ inputs.version }}
+          RELEASE_TYPE: ${{ inputs.release_type }}
 
       - name: Update release files
         run: |
-          npm version "${VERSION}" --no-git-tag-version
           node scripts/prepare-manual-release.mjs "${VERSION}" "${NOTES}"
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
           NOTES: ${{ inputs.notes }}
 
       - name: Create release PR
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: release/manual-v${{ inputs.version }}
+          branch: release/manual-v${{ steps.version.outputs.version }}
           base: master
           delete-branch: true
-          commit-message: "chore(master): release ${{ inputs.version }}"
-          title: "chore(master): release ${{ inputs.version }}"
+          commit-message: "chore(master): release ${{ steps.version.outputs.version }}"
+          title: "chore(master): release ${{ steps.version.outputs.version }}"
           body: |
-            Manual release PR for `v${{ inputs.version }}`.
+            Manual `${{ inputs.release_type }}` release PR for `v${{ steps.version.outputs.version }}`.
 
             This updates:
             - `package.json`

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,11 +6,6 @@ on:
       - master
   workflow_dispatch:
     inputs:
-      release_as:
-        description: "Open a release PR for this exact version (example: 0.13.1)"
-        required: false
-        default: ''
-        type: string
       simulate_publish_failure:
         description: Simulate npm publish failure (for rollback test)
         required: false
@@ -30,20 +25,25 @@ jobs:
       - uses: actions/checkout@v4
 
   release-please-pr:
-    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.reconcile_tag == '') }}
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.reconcile_tag == '' && inputs.simulate_publish_failure == true) }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
       id-token: write
     steps:
+      - name: Checkout repository
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - id: release
         uses: GoogleCloudPlatform/release-please-action@v4
         with:
           include-component-in-tag: false
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          release-as: ${{ inputs.release_as }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Normalize release outputs
@@ -86,9 +86,38 @@ jobs:
           echo "tag_name=${TAG_NAME}"
           echo "sha=${RELEASE_SHA}"
 
+      - name: Resolve manual release commit
+        id: manual-release
+        if: ${{ github.event_name == 'push' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG_NAME="v${VERSION}"
+
+          if gh release view "${TAG_NAME}" >/dev/null 2>&1; then
+            echo "created=false" >> "${GITHUB_OUTPUT}"
+            echo "tag_name=" >> "${GITHUB_OUTPUT}"
+            echo "sha=" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          echo "created=true" >> "${GITHUB_OUTPUT}"
+          echo "tag_name=${TAG_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "sha=${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create GitHub release for manual release
+        if: ${{ steps.release-meta.outputs.release_created != 'true' && steps.manual-release.outputs.created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.manual-release.outputs.tag_name }}
+        run: |
+          awk '/^## \[/{section++} section == 1 {print} section == 2 {exit}' CHANGELOG.md > /tmp/release-notes.md
+          gh release create "${TAG_NAME}" --target "${GITHUB_SHA}" --title "${TAG_NAME}" --notes-file /tmp/release-notes.md
+
       - name: Checkout Repo
         uses: actions/checkout@v4
-        if: ${{ steps.release-meta.outputs.release_created == 'true' }}
+        if: ${{ steps.release-meta.outputs.release_created == 'true' || steps.manual-release.outputs.created == 'true' }}
         with:
           fetch-depth: 0
           ref: master
@@ -97,23 +126,23 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24
-        if: ${{ steps.release-meta.outputs.release_created == 'true' }}
+        if: ${{ steps.release-meta.outputs.release_created == 'true' || steps.manual-release.outputs.created == 'true' }}
 
       - name: Ensure npm 11.5.1+
         run: |
           npm install -g npm@^11.5.1
           node --version
           npm --version
-        if: ${{ steps.release-meta.outputs.release_created == 'true' }}
+        if: ${{ steps.release-meta.outputs.release_created == 'true' || steps.manual-release.outputs.created == 'true' }}
 
       - name: Install dependencies
         run: npm ci
-        if: ${{ steps.release-meta.outputs.release_created == 'true' }}
+        if: ${{ steps.release-meta.outputs.release_created == 'true' || steps.manual-release.outputs.created == 'true' }}
 
       - name: Publish package on NPM 📦
         id: publish
         continue-on-error: true
-        if: ${{ steps.release-meta.outputs.release_created == 'true' }}
+        if: ${{ steps.release-meta.outputs.release_created == 'true' || steps.manual-release.outputs.created == 'true' }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.simulate_publish_failure }}" = "true" ]; then
             echo "Simulating publish failure."
@@ -123,15 +152,15 @@ jobs:
           npm publish --access public
 
       - name: Build docs
-        if: ${{ steps.release-meta.outputs.release_created == 'true' && steps.publish.outcome == 'success' }}
+        if: ${{ (steps.release-meta.outputs.release_created == 'true' || steps.manual-release.outputs.created == 'true') && steps.publish.outcome == 'success' }}
         run: npm run docs:build
 
       - name: Build Storybook under docs
-        if: ${{ steps.release-meta.outputs.release_created == 'true' && steps.publish.outcome == 'success' }}
+        if: ${{ (steps.release-meta.outputs.release_created == 'true' || steps.manual-release.outputs.created == 'true') && steps.publish.outcome == 'success' }}
         run: npm run build-storybook -- -o docs/.vitepress/dist/storybook
 
       - name: Deploy site to gh-pages
-        if: ${{ steps.release-meta.outputs.release_created == 'true' && steps.publish.outcome == 'success' }}
+        if: ${{ (steps.release-meta.outputs.release_created == 'true' || steps.manual-release.outputs.created == 'true') && steps.publish.outcome == 'success' }}
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -139,11 +168,11 @@ jobs:
           publish_dir: ./docs/.vitepress/dist
 
       - name: Roll back failed release by opening PR
-        if: ${{ steps.release-meta.outputs.release_created == 'true' && steps.publish.outcome == 'failure' }}
+        if: ${{ (steps.release-meta.outputs.release_created == 'true' || steps.manual-release.outputs.created == 'true') && steps.publish.outcome == 'failure' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ steps.release-meta.outputs.tag_name }}
-          RELEASE_SHA: ${{ steps.release-meta.outputs.sha }}
+          TAG_NAME: ${{ steps.release-meta.outputs.tag_name || steps.manual-release.outputs.tag_name }}
+          RELEASE_SHA: ${{ steps.release-meta.outputs.sha || steps.manual-release.outputs.sha }}
         run: |
           set -euo pipefail
           echo "Publish failed for ${TAG_NAME}. Cleaning release metadata and opening rollback PR."
@@ -205,7 +234,7 @@ jobs:
           fi
 
       - name: Mark workflow as failed after rollback
-        if: ${{ steps.release-meta.outputs.release_created == 'true' && steps.publish.outcome == 'failure' }}
+        if: ${{ (steps.release-meta.outputs.release_created == 'true' || steps.manual-release.outputs.created == 'true') && steps.publish.outcome == 'failure' }}
         run: |
           echo "Publish failed. Rollback PR was created."
           exit 1

--- a/scripts/prepare-manual-release.mjs
+++ b/scripts/prepare-manual-release.mjs
@@ -1,0 +1,34 @@
+import fs from 'node:fs';
+
+const [, , version, notes = 'Manual release.'] = process.argv;
+
+if (!version) {
+  throw new Error('Usage: node scripts/prepare-manual-release.mjs <version> [notes]');
+}
+
+const today = new Date().toISOString().slice(0, 10);
+
+const manifestPath = '.release-please-manifest.json';
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+manifest['.'] = version;
+fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+const changelogPath = 'CHANGELOG.md';
+const changelog = fs.readFileSync(changelogPath, 'utf8');
+const currentVersion = changelog.match(/^## \[([^\]]+)\]/m)?.[1] ?? 'previous';
+const releaseHeader = `## [${version}](https://github.com/mylmz10/vue-material-3/compare/v${currentVersion}...v${version}) (${today})`;
+const releaseNotes = notes
+  .split(/\r?\n/)
+  .map((line) => line.trim())
+  .filter(Boolean)
+  .map((line) => `* ${line}`)
+  .join('\n');
+const releaseBlock = `${releaseHeader}\n\n\n### Changes\n\n${releaseNotes || '* Manual release.'}\n\n`;
+
+const unreleasedHeading = '## Unreleased\n\n';
+if (!changelog.includes(unreleasedHeading)) {
+  throw new Error('Could not find Unreleased section in CHANGELOG.md');
+}
+
+const updatedChangelog = changelog.replace(unreleasedHeading, `${unreleasedHeading}${releaseBlock}`);
+fs.writeFileSync(changelogPath, updatedChangelog);


### PR DESCRIPTION
## Summary
- revert the non-working manual release_as support from the release-please workflow
- add a separate manual-release-pr workflow that accepts a target version and creates a release PR
- add a small script to update package files, the release manifest, and CHANGELOG for manual release PRs
- keep the existing master push release flow, including npm publish and docs + Storybook deploy

## Validation
- node --check scripts/prepare-manual-release.mjs
- parsed release workflow YAML locally

## Usage
Run the manual-release-pr workflow from Actions, enter a version such as 0.13.1, then merge the generated release PR. After that merge, the existing release workflow publishes npm and deploys docs + Storybook.